### PR TITLE
fix(repo): drop stale TAX_FAMILY references (v0.2.1 P1 hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to Peptide Repo Core are documented here.
 Format: [Semantic Versioning](https://semver.org/).
 
+## [0.2.1] — 2026-04-22
+
+### Fixed
+- **P1 hotfix: fatal `Undefined constant PR_Core_Peptide_CPT::TAX_FAMILY` on every peptide page.** The v0.2.0 release removed `TAX_FAMILY` from `PR_Core_Peptide_CPT` but left two stale references in `PR_Core_Peptide_Repository` (the `family` filter branch in `find_all()` and the families lookup in `post_to_dto()`). JSON-LD emission on single-peptide templates called `find_by_id()`, which called `post_to_dto()`, which hit the undefined constant and killed page rendering mid-`wp_head()`. QA gate on `874f93b` missed this because the unit tests cover the CPT class in isolation, not the repository's consumption of its constants. Post-mortem + QA checklist update to follow.
+
+### Changed
+- `PR_Core_Peptide_Repository::find_all()` — `family` filter is now silently ignored rather than throwing. Next minor bump will remove it from the REST schema.
+- `PR_Core_Peptide_DTO::$families` is preserved but always populated as `[]`. Keeps REST response shape stable for existing clients; will be dropped with a release note.
+
 ## [0.2.0] — 2026-04-22
 
 ### Changed (BREAKING)

--- a/includes/repositories/class-pr-core-peptide-repository.php
+++ b/includes/repositories/class-pr-core-peptide-repository.php
@@ -92,14 +92,10 @@ class PR_Core_Peptide_Repository {
 			] ];
 		}
 
-		if ( ! empty( $filters['family'] ) ) {
-			$args['tax_query']   = $args['tax_query'] ?? [];
-			$args['tax_query'][] = [
-				'taxonomy' => PR_Core_Peptide_CPT::TAX_FAMILY,
-				'field'    => 'slug',
-				'terms'    => sanitize_text_field( $filters['family'] ),
-			];
-		}
+		// v0.2.0: `family` filter silently ignored — `pr_peptide_family` taxonomy
+		// was removed with the CPT consolidation. Callers passing `family` get
+		// all-category results rather than a fatal. Remove this key from the
+		// REST schema in a future minor bump.
 
 		if ( ! empty( $filters['evidence_strength'] ) ) {
 			$args['meta_query'] = [ [
@@ -135,7 +131,10 @@ class PR_Core_Peptide_Repository {
 		$aliases     = json_decode( $aliases_raw ?: '[]', true ) ?: [];
 
 		$categories = wp_get_post_terms( $post->ID, PR_Core_Peptide_CPT::TAX_CATEGORY, [ 'fields' => 'names' ] );
-		$families   = wp_get_post_terms( $post->ID, PR_Core_Peptide_CPT::TAX_FAMILY, [ 'fields' => 'names' ] );
+		// v0.2.0: `pr_peptide_family` taxonomy removed. DTO `families` field
+		// preserved as empty array to keep the REST response shape stable for
+		// clients; will be dropped in a future minor bump with a release note.
+		$families   = [];
 
 		return new PR_Core_Peptide_DTO( [
 			'id'                       => $post->ID,
@@ -156,7 +155,7 @@ class PR_Core_Peptide_Repository {
 			'last_editorial_review_at' => get_post_meta( $post->ID, 'last_editorial_review_at', true ) ?: '',
 			'medical_editor_id'        => (int) get_post_meta( $post->ID, 'medical_editor_id', true ),
 			'categories'               => is_array( $categories ) ? $categories : [],
-			'families'                 => is_array( $families ) ? $families : [],
+			'families'                 => $families,
 		] );
 	}
 }

--- a/peptide-repo-core.php
+++ b/peptide-repo-core.php
@@ -3,7 +3,7 @@
  * Plugin Name: Peptide Repo Core
  * Plugin URI:  https://peptiderepo.com
  * Description: Canonical peptide schema — shared data layer for the peptiderepo.com ecosystem. Provides the peptide CPT, dosing rows, legal status cells, AI candidate queue, disclaimer component, and JSON-LD output.
- * Version:     0.2.0
+ * Version:     0.2.1
  * Author:      peptiderepo
  * Author URI:  https://peptiderepo.com
  * License:     GPL-2.0-or-later
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /* ── Constants ────────────────────────────────────────────────────────── */
 
-define( 'PR_CORE_VERSION', '0.2.0' );
+define( 'PR_CORE_VERSION', '0.2.1' );
 define( 'PR_CORE_PLUGIN_FILE', __FILE__ );
 define( 'PR_CORE_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PR_CORE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary

**P1 hotfix.** v0.2.0 removed `TAX_FAMILY` from `PR_Core_Peptide_CPT` but left two stale references in `PR_Core_Peptide_Repository`:

- `find_all()` `family` filter branch (line 95-102)
- `post_to_dto()` families taxonomy lookup (line 138)

JSON-LD emission on single-peptide templates called `find_by_id()` → `post_to_dto()` which hit the undefined constant and killed every peptide detail page render mid-`wp_head()`. Fatal reproduced in prod logs: `/wp-content/uploads/wc-logs/fatal-errors-2026-04-22-*.log`.

## Changes

- `find_all()` `family` filter silently ignored until a future minor bump removes it from the REST schema.
- `post_to_dto()` hardcodes `$families = []` so the DTO still carries the field (REST response shape unchanged for existing clients).
- Version bump 0.2.0 → 0.2.1 with CHANGELOG entry in the same commit.

## Out-of-scope follow-ups

- Post-mortem on why the v0.2.0 QA gate missed this. Unit tests exercised the CPT class in isolation, not the repository's consumption of its constants.
- Add an integration-style test for JSON-LD emission on a single peptide so any future CPT-class refactor catches repository drift.

## Verification

After deploy:
```
curl -sI https://peptiderepo.com/peptides/bpc-157/ | head -1
# -> HTTP/2 200
curl -s https://peptiderepo.com/peptides/bpc-157/ | grep -c "wp-die-message"
# -> 0
```
