### PR TITLE
fix(cpt): remove rest_namespace so Gutenberg block editor can load peptide posts (v0.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to Peptide Repo Core are documented here.
 Format: [Semantic Versioning](https://semver.org/).
 
+## [0.2.1] — 2026-04-22
+
+### Fixed
+- **P1 hotfix: fatal `Undefined constant PR_Core_Peptide_CPT::TAX_FAMILY` on every peptide page.** The v0.2.0 release removed `TAX_FAMILY` from `PR_Core_Peptide_CPT` but left two stale references in `PR_Core_Peptide_Repository` (the `family` filter branch in `find_all()` and the families lookup in `post_to_dto()`). JSON-LD emission on single-peptide templates called `find_by_id()`, which called `post_to_dto()`, which hit the undefined constant and killed page rendering mid-`wp_head()`. QA gate on `874f93b` missed this because the unit tests cover the CPT class in isolation, not the repository's consumption of its constants. Post-mortem + QA checklist update to follow.
+
+### Changed
+- `PR_Core_Peptide_Repository::find_all()` — `family` filter is now silently ignored rather than throwing. Next minor bump will remove it from the REST schema.
+- `PR_Core_Peptide_DTO::$families` is preserved but always populated as `[]`. Keeps REST response shape stable for existing clients; will be dropped with a release note.
+
 ## [0.2.0] — 2026-04-22
 
 ### Changed (BREAKING)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to Peptide Repo Core are documented here.
 Format: [Semantic Versioning](https://semver.org/).
 
+## [0.2.2] — 2026-04-25
+
+### Fixed
+- Remove `rest_namespace` from peptide CPT registration. Custom namespace prevented Gutenberg block editor from loading peptide posts for editing (404 on wp/v2 REST route). All 89 peptide entries are now editable in the block editor.
+
 ## [0.2.1] — 2026-04-22
 
 ### Fixed
@@ -65,7 +70,4 @@ Format: [Semantic Versioning](https://semver.org/).
 - JSON-LD emission: schema.org `Drug` type on single peptide pages with `pr_core_jsonld_peptide` filter.
 - Public API filters: `pr_core_get_indexable_corpus`, `pr_core_disclaimer_for_surface`, `pr_core_evidence_strength_label`.
 - Public API actions: `pr_core_before/after_peptide_publish`, `pr_core_before/after_dosing_row_publish`, `pr_core_before/after_legal_cell_publish`, `pr_core_candidate_approved/rejected`.
-- `manage_peptide_content` capability granted to administrators and editors on activation.
-- Full teardown in `uninstall.php` (tables, posts, terms, options, capabilities).
-- Seed data fixture: 3 peptides (BPC-157, Semaglutide, TB-500), 10 dosing rows, 5 legal cells.
-- CI workflow: PHP lint (8.0/8.1/8.2), PHPCS (WordPress standard), 300-line file check.
+- `manage_peptide_content` capability granted to administrators and editors on activ

--- a/includes/cpt/class-pr-core-peptide-cpt.php
+++ b/includes/cpt/class-pr-core-peptide-cpt.php
@@ -2,9 +2,10 @@
 declare(strict_types=1);
 
 /**
- * Registers the peptide custom post type and associated taxonomy.
+ * Registers the peptide custom post type and associated taxonomies.
  *
  * What: Defines the peptide CPT with REST support, archive, and monograph meta fields.
+ *       Also registers the peptide_category taxonomy (for peptide categorization).
  * Who calls it: PR_Core::init() on plugins_loaded.
  * Dependencies: None.
  *
@@ -183,10 +184,8 @@ class PR_Core_Peptide_CPT {
 			'show_in_nav_menus'  => true,
 			'show_in_rest'       => true,
 			'rest_base'          => 'peptides',
-			// Note: 'rest_namespace' is deliberately omitted. Custom namespaces prevent
-			// Gutenberg's block editor from loading posts for editing (it fetches the
-			// hardcoded wp/v2 REST route). WordPress defaults to wp/v2 — appropriate for
-			// this CPT — and keeps the REST endpoint at /wp-json/wp/v2/peptides/.
+			// 'rest_namespace' omitted — custom namespaces break Gutenberg (it
+			// fetches wp/v2 hardcoded). WordPress defaults to wp/v2. (#4)
 			'menu_position'      => 25,
 			'menu_icon'          => 'dashicons-database',
 			'capability_type'    => 'post',
@@ -204,35 +203,36 @@ class PR_Core_Peptide_CPT {
 	 * Register the `peptide_category` taxonomy.
 	 *
 	 * Guarded with `taxonomy_exists()` for the same reason CPT registration
-	 * is guarded. The 8 existing terms + term_relationships stay intact —
+	 * is guarded. The 8 existing category terms + term_relationships stay intact —
 	 * they key on taxonomy name `peptide_category` in wp_term_taxonomy,
 	 * which is exactly what we register here.
 	 *
 	 * v0.2.0: `pr_peptide_family` taxonomy removed — never populated, never
 	 * surfaced in UI.
 	 *
+	 * v0.3.0: `peptide_topic` taxonomy moved to PR_Core_Topic_Taxonomy class.
+	 *
 	 * Side effects: registers taxonomy with WordPress.
 	 *
 	 * @return void
 	 */
 	public static function register_taxonomies(): void {
-		if ( taxonomy_exists( self::TAX_CATEGORY ) ) {
-			return;
+		// Register peptide_category taxonomy.
+		if ( ! taxonomy_exists( self::TAX_CATEGORY ) ) {
+			register_taxonomy( self::TAX_CATEGORY, self::POST_TYPE, [
+				'labels'             => [
+					'name'          => __( 'Peptide Categories', 'peptide-repo-core' ),
+					'singular_name' => __( 'Peptide Category', 'peptide-repo-core' ),
+				],
+				'public'             => true,
+				'publicly_queryable' => true,
+				'show_in_rest'       => true,
+				'show_ui'            => true,
+				'show_admin_column'  => true,
+				'hierarchical'       => true,
+				'rewrite'            => [ 'slug' => 'peptide-category', 'with_front' => false ],
+			] );
 		}
-
-		register_taxonomy( self::TAX_CATEGORY, self::POST_TYPE, [
-			'labels'             => [
-				'name'          => __( 'Peptide Categories', 'peptide-repo-core' ),
-				'singular_name' => __( 'Peptide Category', 'peptide-repo-core' ),
-			],
-			'public'             => true,
-			'publicly_queryable' => true,
-			'show_in_rest'       => true,
-			'show_ui'            => true,
-			'show_admin_column'  => true,
-			'hierarchical'       => true,
-			'rewrite'            => [ 'slug' => 'peptide-category', 'with_front' => false ],
-		] );
 	}
 
 	/**
@@ -288,4 +288,11 @@ class PR_Core_Peptide_CPT {
 	/**
 	 * Sanitize editorial_review_status to allowed enum values.
 	 *
-	
+	 * @param mixed $value Raw input.
+	 * @return string Valid enum value.
+	 */
+	public static function sanitize_review_status( $value ): string {
+		$value = sanitize_text_field( (string) $value );
+		return in_array( $value, self::REVIEW_STATUSES, true ) ? $value : 'draft';
+	}
+}

--- a/includes/cpt/class-pr-core-peptide-cpt.php
+++ b/includes/cpt/class-pr-core-peptide-cpt.php
@@ -183,7 +183,10 @@ class PR_Core_Peptide_CPT {
 			'show_in_nav_menus'  => true,
 			'show_in_rest'       => true,
 			'rest_base'          => 'peptides',
-			'rest_namespace'     => 'pr-core/v1',
+			// Note: 'rest_namespace' is deliberately omitted. Custom namespaces prevent
+			// Gutenberg's block editor from loading posts for editing (it fetches the
+			// hardcoded wp/v2 REST route). WordPress defaults to wp/v2 — appropriate for
+			// this CPT — and keeps the REST endpoint at /wp-json/wp/v2/peptides/.
 			'menu_position'      => 25,
 			'menu_icon'          => 'dashicons-database',
 			'capability_type'    => 'post',
@@ -285,11 +288,4 @@ class PR_Core_Peptide_CPT {
 	/**
 	 * Sanitize editorial_review_status to allowed enum values.
 	 *
-	 * @param mixed $value Raw input.
-	 * @return string Valid enum value.
-	 */
-	public static function sanitize_review_status( $value ): string {
-		$value = sanitize_text_field( (string) $value );
-		return in_array( $value, self::REVIEW_STATUSES, true ) ? $value : 'draft';
-	}
-}
+	

--- a/includes/repositories/class-pr-core-peptide-repository.php
+++ b/includes/repositories/class-pr-core-peptide-repository.php
@@ -92,14 +92,10 @@ class PR_Core_Peptide_Repository {
 			] ];
 		}
 
-		if ( ! empty( $filters['family'] ) ) {
-			$args['tax_query']   = $args['tax_query'] ?? [];
-			$args['tax_query'][] = [
-				'taxonomy' => PR_Core_Peptide_CPT::TAX_FAMILY,
-				'field'    => 'slug',
-				'terms'    => sanitize_text_field( $filters['family'] ),
-			];
-		}
+		// v0.2.0: `family` filter silently ignored — `pr_peptide_family` taxonomy
+		// was removed with the CPT consolidation. Callers passing `family` get
+		// all-category results rather than a fatal. Remove this key from the
+		// REST schema in a future minor bump.
 
 		if ( ! empty( $filters['evidence_strength'] ) ) {
 			$args['meta_query'] = [ [
@@ -135,7 +131,10 @@ class PR_Core_Peptide_Repository {
 		$aliases     = json_decode( $aliases_raw ?: '[]', true ) ?: [];
 
 		$categories = wp_get_post_terms( $post->ID, PR_Core_Peptide_CPT::TAX_CATEGORY, [ 'fields' => 'names' ] );
-		$families   = wp_get_post_terms( $post->ID, PR_Core_Peptide_CPT::TAX_FAMILY, [ 'fields' => 'names' ] );
+		// v0.2.0: `pr_peptide_family` taxonomy removed. DTO `families` field
+		// preserved as empty array to keep the REST response shape stable for
+		// clients; will be dropped in a future minor bump with a release note.
+		$families   = [];
 
 		return new PR_Core_Peptide_DTO( [
 			'id'                       => $post->ID,
@@ -156,7 +155,7 @@ class PR_Core_Peptide_Repository {
 			'last_editorial_review_at' => get_post_meta( $post->ID, 'last_editorial_review_at', true ) ?: '',
 			'medical_editor_id'        => (int) get_post_meta( $post->ID, 'medical_editor_id', true ),
 			'categories'               => is_array( $categories ) ? $categories : [],
-			'families'                 => is_array( $families ) ? $families : [],
+			'families'                 => $families,
 		] );
 	}
 }

--- a/peptide-repo-core.php
+++ b/peptide-repo-core.php
@@ -3,7 +3,7 @@
  * Plugin Name: Peptide Repo Core
  * Plugin URI:  https://peptiderepo.com
  * Description: Canonical peptide schema — shared data layer for the peptiderepo.com ecosystem. Provides the peptide CPT, dosing rows, legal status cells, AI candidate queue, disclaimer component, and JSON-LD output.
- * Version:     0.2.0
+ * Version:     0.2.1
  * Author:      peptiderepo
  * Author URI:  https://peptiderepo.com
  * License:     GPL-2.0-or-later
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /* ── Constants ────────────────────────────────────────────────────────── */
 
-define( 'PR_CORE_VERSION', '0.2.0' );
+define( 'PR_CORE_VERSION', '0.2.1' );
 define( 'PR_CORE_PLUGIN_FILE', __FILE__ );
 define( 'PR_CORE_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PR_CORE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/peptide-repo-core.php
+++ b/peptide-repo-core.php
@@ -3,7 +3,7 @@
  * Plugin Name: Peptide Repo Core
  * Plugin URI:  https://peptiderepo.com
  * Description: Canonical peptide schema — shared data layer for the peptiderepo.com ecosystem. Provides the peptide CPT, dosing rows, legal status cells, AI candidate queue, disclaimer component, and JSON-LD output.
- * Version:     0.2.1
+ * Version:     0.2.2
  * Author:      peptiderepo
  * Author URI:  https://peptiderepo.com
  * License:     GPL-2.0-or-later
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /* ── Constants ────────────────────────────────────────────────────────── */
 
-define( 'PR_CORE_VERSION', '0.2.1' );
+define( 'PR_CORE_VERSION', '0.2.2' );
 define( 'PR_CORE_PLUGIN_FILE', __FILE__ );
 define( 'PR_CORE_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PR_CORE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
Closing — branch based on v0.2.0 merge base, 25 commits behind main. Fix will be re-applied cleanly from main as v0.3.2.