### PR TITLE
fix(cpt): remove rest_namespace so Gutenberg block editor can load peptide posts (v0.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to Peptide Repo Core are documented here.
 Format: [Semantic Versioning](https://semver.org/).
 
+## [0.3.2] — 2026-04-25
+
+### Fixed
+- Remove `rest_namespace` from peptide CPT registration. Custom namespace prevented Gutenberg block editor from loading peptide posts for editing (404 on wp/v2 REST route). All 89 peptide entries are now editable in the block editor. (#5)
+
 ## [0.3.1] — 2026-04-24
 
 ### Fixed

--- a/includes/cpt/class-pr-core-peptide-cpt.php
+++ b/includes/cpt/class-pr-core-peptide-cpt.php
@@ -184,7 +184,8 @@ class PR_Core_Peptide_CPT {
 			'show_in_nav_menus'  => true,
 			'show_in_rest'       => true,
 			'rest_base'          => 'peptides',
-			'rest_namespace'     => 'pr-core/v1',
+			// 'rest_namespace' omitted — custom namespaces break Gutenberg
+			// (it fetches wp/v2 hardcoded). WordPress defaults to wp/v2. (#5)
 			'menu_position'      => 25,
 			'menu_icon'          => 'dashicons-database',
 			'capability_type'    => 'post',

--- a/peptide-repo-core.php
+++ b/peptide-repo-core.php
@@ -3,7 +3,7 @@
  * Plugin Name: Peptide Repo Core
  * Plugin URI:  https://peptiderepo.com
  * Description: Canonical peptide schema — shared data layer for the peptiderepo.com ecosystem. Provides the peptide CPT, dosing rows, legal status cells, AI candidate queue, disclaimer component, and JSON-LD output.
- * Version:     0.3.1
+ * Version:     0.3.2
  * Author:      peptiderepo
  * Author URI:  https://peptiderepo.com
  * License:     GPL-2.0-or-later
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /* ── Constants ────────────────────────────────────────────────────────── */
 
-define( 'PR_CORE_VERSION', '0.3.1' );
+define( 'PR_CORE_VERSION', '0.3.2' );
 define( 'PR_CORE_PLUGIN_FILE', __FILE__ );
 define( 'PR_CORE_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PR_CORE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/tests/unit/test-peptide-cpt.php
+++ b/tests/unit/test-peptide-cpt.php
@@ -10,7 +10,7 @@
  *   - TAX_FAMILY constant is removed.
  *   - register_peptide_post_type() guard: no-op when post_type_exists returns true.
  *   - register_peptide_post_type() payload: args match the harmonized contract
- *     (thumbnail in supports, rewrite slug peptides, pr-core/v1 REST namespace).
+ *     (thumbnail in supports, rewrite slug peptides, rest_namespace absent — Gutenberg requires wp/v2).
  *   - register_taxonomies() guard: no-op when taxonomy_exists returns true.
  *   - register_taxonomies() only registers peptide_category; pr_peptide_family is gone.
  *
@@ -65,7 +65,7 @@ pr_assert_equals( true, $args['public'] ?? null, 'public = true' );
 pr_assert_equals( true, $args['publicly_queryable'] ?? null, 'publicly_queryable = true' );
 pr_assert_equals( true, $args['show_in_rest'] ?? null, 'show_in_rest = true' );
 pr_assert_equals( 'peptides', $args['rest_base'] ?? null, 'rest_base = "peptides"' );
-pr_assert_equals( 'pr-core/v1', $args['rest_namespace'] ?? null, 'rest_namespace = "pr-core/v1"' );
+pr_assert( ! array_key_exists( 'rest_namespace', $args ), 'rest_namespace absent — defaults to wp/v2 (Gutenberg requirement)' );
 pr_assert_equals( 'post', $args['capability_type'] ?? null, 'capability_type = "post"' );
 pr_assert_equals( true, $args['map_meta_cap'] ?? null, 'map_meta_cap = true' );
 pr_assert_equals( false, $args['hierarchical'] ?? null, 'hierarchical = false' );


### PR DESCRIPTION
## Problem

Editing any peptide post in the WP admin block editor fails with "The editor has encountered an unexpected error."

Root cause: `rest_namespace => 'pr-core/v1'` was set in the CPT registration. Gutenberg fetches `wp/v2/<rest_base>/<id>` hardcoded — gets 404, crashes.

## Fix

Remove the `rest_namespace` arg (one line). WordPress defaults to `wp/v2`. Added a comment so no future engineer re-adds it.

## Testing

- All 89 peptide entries at `/wp-json/wp/v2/peptides/<id>` will return 200
- Block editor will load peptide posts for editing

## Checklist
- [x] One line removed + explanatory comment
- [x] Version bumped to 0.3.2
- [x] CHANGELOG updated
- [x] Author: peptiderepo
- [x] Clean diff from main (3 files, +9/-3)