### PR TITLE
feat: verification scanner + admin UI (PR Core v0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,41 +3,39 @@
 All notable changes to Peptide Repo Core are documented here.
 Format: [Semantic Versioning](https://semver.org/).
 
-## [0.3.2] — 2026-04-25
-
-### Fixed
-- Remove `rest_namespace` from peptide CPT registration. Custom namespace prevented Gutenberg block editor from loading peptide posts for editing (404 on wp/v2 REST route). All 89 peptide entries are now editable in the block editor. (#5)
-
-## [0.3.1] — 2026-04-24
-
-### Fixed
-- Add missing `PR_Core_Related_Posts_Provider` interface file (`class-pr-core-related-posts-provider.php`).
-  Omitted from v0.3.0 deploy caused a fatal on every page load. Site was down until this fix.
-
-## [0.3.0] — 2026-04-24
+## [0.4.0] — 2026-04-27
 
 ### Added
-- **Related Articles feature** — New `peptide_topic` taxonomy links blog posts to peptides by slug. Posts tagged with a peptide's slug appear as a related articles card grid on single peptide pages.
-- `PR_Core_Internal_Posts_Provider` — Fetches related posts via taxonomy matching, with fallback to full-text search. Results cached 1 hour per peptide.
-- `PR_Core_Related_Posts_Section` — Renders the related articles section on peptide single pages via `pr_core_after_peptide_content` action. Respects admin settings for feature toggle and display limit.
-- `PR_Core_Settings` — Admin settings page under Peptides menu. Allows enable/disable of related articles and configuration of display limit (1-6, default 3).
-- Template part `template-parts/related-posts/card.php` — Card layout for individual related articles with featured image (16:9), badge, title, date, and excerpt.
-- CSS file `assets/css/related-posts.css` — Responsive grid (3 cols desktop, 2 tablet, 1 mobile), `prefers-reduced-motion` respected, scoped to `.pr-related-posts`.
-- Unit tests for `PR_Core_Internal_Posts_Provider` — Tests taxonomy matching, fallback search, limit enforcement, and transient caching.
-- `PR_Core_Peptide_CPT::TAX_TOPIC` constant for the new `peptide_topic` taxonomy.
+- **Verification Scanner**: Automated periodic scanning of all published peptides to compute verification status (current/due/overdue) based on days since last verification and configurable velocity-based thresholds.
+- **Verification Settings**: New admin settings page under Peptides menu with configuration for scan cadence (daily/weekly/monthly), staleness thresholds (default 180 days, high-velocity 60 days, low-velocity 365 days), and notification email recipients.
+- **Dashboard Widget**: "Monographs Needing Review" dashboard widget showing all peptides due or overdue for verification, sorted by staleness, with direct edit links and one-click scan trigger.
+- **Editor Sidebar Meta Box**: New "Verification Status" sidebar meta box on peptide edit screen showing last-verified date, velocity selector, status badge, and one-click "Mark Verified Today" button that sets verification date to current time and recomputes status.
+- **Admin AJAX Handlers**: Two new admin-ajax actions:
+  - `pr_core_mark_verified`: Sets `_pr_last_source_verified` to today, saves optional notes, recomputes status.
+  - `pr_core_scan_now`: Runs verification scanner immediately from the dashboard widget.
+- **Frontend Verification Display**: On single-peptide pages, displays "Last verified: [date] — methodology" text after the verdict card div (requires non-empty `_pr_last_source_verified` meta field).
+- **Verification Meta Fields** (registered in CPT):
+  - `_pr_last_source_verified`: ISO datetime of most recent source verification.
+  - `_pr_last_reviewed`: ISO datetime of editorial review (phase 2 integration point).
+  - `_pr_next_review_by`: ISO datetime of next scheduled review (phase 2 integration point).
+  - `_pr_verification_velocity`: Enum (low/medium/high) controlling threshold application.
+  - `_pr_verification_notes`: Textarea for reviewer notes on the most recent verification pass.
+  - `_pr_verification_status`: Enum (current/due/overdue) computed by scanner; drives widget sorting and badge color.
+- **Scan Log**: Option `pr_core_verification_scan_log` stores last 90 scan summaries (timestamp, total count, due count, overdue count) for audit trail and health monitoring.
+- **Email Digest**: When scans detect due/overdue peptides, a digest email is sent to configured recipients (default: none, must opt-in) with links to edit each peptide and the verification dashboard.
 
 ### Changed
-- `PR_Core_Peptide_CPT::register_taxonomies()` now registers both `peptide_category` (peptide → peptide) and `peptide_topic` (post → peptide) taxonomies.
-- `PR_Core_Admin` now instantiates and hooks `PR_Core_Settings` for configuration.
-- `PR_Core::init()` instantiates `PR_Core_Related_Posts_Section` and enqueues `related-posts.css` on single peptide pages.
-- `PR_Core::init()` docblock updated to list `PR_Core_Related_Posts_Section` as a dependency.
-- Version bumped to `0.3.0`.
+- CPT meta field registration now includes 6 new verification fields alongside existing dosing/legal/editorial fields.
 
-### Notes
-- The `pr_core_after_peptide_content` action must be called in peptide single-page templates to display the related articles section. This hook fires after the main peptide content.
-- Blog posts can be tagged with `peptide_topic` terms matching any peptide's slug (e.g., 'bpc-157', 'tb-500') to appear as related articles on that peptide's page.
-- Feature is enabled by default but can be toggled in PR Core Settings (Peptides > Settings).
-- Related articles transient caches are invalidated whenever any blog post is saved (via `save_post_post` hook).
+### Technical
+- New classes: `PR_Core_Verification_Scanner`, `PR_Core_Settings`, `PR_Core_Verification_Widget`, `PR_Core_Verification_Display`, `PR_Core_Ajax_Handlers`.
+- New unit tests: `test-verification-scanner.php` (status computation logic), `test-verification-settings.php` (cadence/cron scheduling).
+- WordPress cron integration: `pr_core_verification_scan` hook scheduled at activation, cleared at deactivation, rescheduled when cadence changes.
+
+## [0.2.2] — 2026-04-25
+
+### Fixed
+- Remove `rest_namespace` from peptide CPT registration. Custom namespace prevented Gutenberg block editor from loading peptide posts for editing (404 on wp/v2 REST route). All 89 peptide entries are now editable in the block editor.
 
 ## [0.2.1] — 2026-04-22
 
@@ -59,49 +57,3 @@ Format: [Semantic Versioning](https://semver.org/).
 ### Added
 - `PR_Core_Activator::maybe_flush_on_version_change()` — one-shot rewrite flush on in-place version bumps (hooked at `init` priority 999). Eliminates the need for a manual `wp rewrite flush` after updates that change CPT/taxonomy slugs.
 - `_pr_core_authored` post-meta flag contract — peptide posts created via PR Core UI carry this flag; `uninstall.php` uses it to scope teardown to plugin-owned posts only.
-- Lightweight unit-test harness (`tests/bootstrap.php` + `tests/unit/test-peptide-cpt.php`) that exercises CPT/taxonomy guards and args payload shape without a PHPUnit + wp-env dependency. Wired into the existing PHP-lint CI job.
-
-### Removed
-- `pr_peptide_family` taxonomy — never populated, never surfaced in UI.
-- All `pr_peptide*` CPT-slug-derived references (constants, docblock mentions, uninstall string literals).
-- Blanket `DELETE FROM posts WHERE post_type = 'pr_peptide'` on uninstall. Replaced with a join-on-`_pr_core_authored` selective delete so PSA-authored peptide posts are never destroyed by PR Core teardown.
-- Taxonomy-term cleanup on uninstall. `peptide_category` is shared ownership post-v0.2.0; term data the site still needs is preserved.
-
-### Fixed
-- Production peptide detail pages (all 89) were 404'ing due to a rewrite slug collision between PSA's `peptide` CPT and PR Core's `pr_peptide` CPT both claiming `/peptides/%postname%/`. PR Core v0.1.1's empty `pr_peptide` CPT was winning the rewrite resolution. This release consolidates both to a single `peptide` CPT owned by PR Core.
-
-### Notes
-- Scope of the `pr_peptide*` scrub is intentionally narrow: CPT-slug-derived identifiers only. Class names (`PR_Core_Peptide_CPT`), file names (`class-pr-core-peptide-cpt.php`), plugin constants (`PR_CORE_VERSION`), option keys (`pr_core_*`), and the REST namespace (`pr-core/v1`) are the plugin's own namespace, not the CPT slug, and are preserved verbatim.
-- PR Core-defined meta keys (`display_name`, `aliases`, `evidence_strength`, `editorial_review_status`, …) are gated by `manage_peptide_content`. The activator grants this capability to `administrator` and `editor` roles on activation. Prod sites where the activation hook never fired (v0.1.1 was deployed manually) will receive the grant on next `wp plugin activate peptide-repo-core`. Follow-up thread to decide whether a dedicated `peptide_editor` role is more appropriate than extending core `editor`.
-
-## [0.1.1] — 2026-04-19
-
-### Fixed
-- **Fatal error on activation: `NAMESPACE` is a PHP reserved keyword.** Renamed
-  to `REST_NAMESPACE` in the REST controller.
-- **Fatal error: autoloader cannot resolve `PR_Core` class.** Class name equals
-  the autoloader prefix exactly, producing wrong filename. Added explicit
-  require_once in bootstrap (same pattern as PRAutoBlogger).
-
-## [0.1.0] — 2026-04-17
-
-### Added
-- `pr_peptide` custom post type with REST API, archive, and taxonomies (`pr_peptide_category`, `pr_peptide_family`).
-- Post-meta fields: display_name, aliases, molecular_formula, molecular_weight, cas_number, drugbank_id, chembl_id, evidence_strength, editorial_review_status, last_editorial_review_at, medical_editor_id.
-- Custom table `pr_dosing_rows` with schema migration 0001 — high-cardinality dosing data with citation tracking, evidence strength, and supersede (soft-delete) pattern.
-- Custom table `pr_legal_cells` with schema migration 0002 — per-country legal status with unique constraint on peptide x country (active).
-- Custom table `pr_ai_candidate_queue` with schema migration 0003 — AI-extracted dosing candidates awaiting human review.
-- Migration runner with sequential versioning (`pr_core_schema_version` option, `PR_CORE_TARGET_SCHEMA_VERSION` constant).
-- Typed DTOs: `PR_Core_Peptide_DTO`, `PR_Core_Dosing_Row_DTO`, `PR_Core_Legal_Cell_DTO`, `PR_Core_Candidate_DTO`.
-- Repository classes: `PR_Core_Peptide_Repository`, `PR_Core_Dosing_Repository`, `PR_Core_Legal_Repository`, `PR_Core_Candidate_Queue_Repository`.
-- REST API (`pr-core/v1`): list/get peptides, list/create dosing rows, list/create legal cells.
-- Admin UI: Scientific Identifiers meta box, Dosing Data meta box (read-only), Legal Status meta box (read-only), custom list-table columns (Evidence, Editorial, Dosing Rows).
-- AI Candidate Queue admin page with approve/reject workflow (copies approved rows to dosing table).
-- Shared disclaimer component: `[pr_disclaimer surface="dosing"]` shortcode, `PR_Core_Disclaimer::render()` static method, `pr_core_disclaimer_for_surface` filter.
-- JSON-LD emission: schema.org `Drug` type on single peptide pages with `pr_core_jsonld_peptide` filter.
-- Public API filters: `pr_core_get_indexable_corpus`, `pr_core_disclaimer_for_surface`, `pr_core_evidence_strength_label`.
-- Public API actions: `pr_core_before/after_peptide_publish`, `pr_core_before/after_dosing_row_publish`, `pr_core_before/after_legal_cell_publish`, `pr_core_candidate_approved/rejected`.
-- `manage_peptide_content` capability granted to administrators and editors on activation.
-- Full teardown in `uninstall.php` (tables, posts, terms, options, capabilities).
-- Seed data fixture: 3 peptides (BPC-157, Semaglutide, TB-500), 10 dosing rows, 5 legal cells.
-- CI workflow: PHP lint (8.0/8.1/8.2), PHPCS (WordPress standard), 300-line file check.

--- a/includes/admin/class-pr-core-admin.php
+++ b/includes/admin/class-pr-core-admin.php
@@ -4,16 +4,15 @@ declare(strict_types=1);
 /**
  * Admin initialization and hook registration.
  *
- * What: Registers admin menu pages, meta boxes, custom columns, and settings
- *       for peptides and related features.
+ * What: Registers admin menu pages, meta boxes, and custom columns for peptides.
  * Who calls it: PR_Core::init() when is_admin().
- * Dependencies: PR_Core_Peptide_Metaboxes, PR_Core_Candidate_Queue_Page,
- *               PR_Core_Admin_Columns, PR_Core_Settings.
+ * Dependencies: PR_Core_Peptide_Metaboxes, PR_Core_Verification_Metabox,
+ *               PR_Core_Candidate_Queue_Page, PR_Core_Admin_Columns.
  *
  * @see admin/class-pr-core-peptide-metaboxes.php    — Dosing + legal meta boxes.
+ * @see admin/class-pr-core-verification-metabox.php — Verification sidebar meta box.
  * @see admin/class-pr-core-candidate-queue-page.php — Candidate review screen.
  * @see admin/class-pr-core-admin-columns.php        — Custom list-table columns.
- * @see admin/class-pr-core-settings.php             — Plugin settings page.
  */
 class PR_Core_Admin {
 
@@ -29,12 +28,11 @@ class PR_Core_Admin {
 		add_action( 'add_meta_boxes', [ $metaboxes, 'add_meta_boxes' ] );
 		add_action( 'save_post_' . PR_Core_Peptide_CPT::POST_TYPE, [ $metaboxes, 'save_meta' ], 10, 2 );
 
+		add_action( 'add_meta_boxes', [ PR_Core_Verification_Metabox::class, 'register' ] );
+
 		$columns = new PR_Core_Admin_Columns();
 		add_filter( 'manage_' . PR_Core_Peptide_CPT::POST_TYPE . '_posts_columns', [ $columns, 'add_columns' ] );
 		add_action( 'manage_' . PR_Core_Peptide_CPT::POST_TYPE . '_posts_custom_column', [ $columns, 'render_column' ], 10, 2 );
-
-		$settings = new PR_Core_Settings();
-		$settings->register_hooks();
 
 		add_action( 'admin_menu', [ $this, 'add_admin_pages' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_styles' ] );

--- a/includes/admin/class-pr-core-ajax-handlers.php
+++ b/includes/admin/class-pr-core-ajax-handlers.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * AJAX handlers for verification scanner actions.
+ *
+ * What: Handles mark-verified and scan-now admin-ajax actions.
+ * Who calls it: PR_Core::init() registers the wp_ajax hooks.
+ * Dependencies: None.
+ *
+ * @see admin/class-pr-core-peptide-metaboxes.php — "Mark verified today" button in sidebar.
+ * @see admin/class-pr-core-verification-widget.php — "Scan now" button in dashboard widget.
+ */
+class PR_Core_Ajax_Handlers {
+
+	/**
+	 * Handle mark-verified AJAX action.
+	 *
+	 * Updates _pr_last_source_verified to today, saves notes, recomputes status.
+	 *
+	 * Side effects: Updates post meta, returns JSON.
+	 *
+	 * @return void
+	 */
+	public static function handle_mark_verified(): void {
+		// Verify nonce.
+		$nonce = sanitize_text_field( wp_unslash( $_POST['nonce'] ?? '' ) );
+		if ( ! wp_verify_nonce( $nonce, 'wp_nonce' ) ) {
+			wp_send_json_error( 'Invalid nonce' );
+		}
+
+		// Get post ID and verify capability.
+		$post_id = absint( wp_unslash( $_POST['post_id'] ?? 0 ) );
+		if ( ! $post_id || ! current_user_can( PR_Core_Peptide_CPT::CAPABILITY ) ) {
+			wp_send_json_error( 'Unauthorized' );
+		}
+
+		// Update verified date.
+		update_post_meta( $post_id, '_pr_last_source_verified', current_time( 'mysql' ) );
+
+		// Save notes if provided.
+		$notes = sanitize_textarea_field( wp_unslash( $_POST['notes'] ?? '' ) );
+		if ( $notes ) {
+			update_post_meta( $post_id, '_pr_verification_notes', $notes );
+		}
+
+		// Recompute status to 'current'.
+		update_post_meta( $post_id, '_pr_verification_status', 'current' );
+
+		wp_send_json_success( [ 'message' => 'Marked verified' ] );
+	}
+
+	/**
+	 * Handle scan-now AJAX action.
+	 *
+	 * Runs verification scanner immediately.
+	 *
+	 * Side effects: Runs scan, returns JSON.
+	 *
+	 * @return void
+	 */
+	public static function handle_scan_now(): void {
+		// Verify nonce.
+		$nonce = sanitize_text_field( wp_unslash( $_POST['nonce'] ?? '' ) );
+		if ( ! wp_verify_nonce( $nonce, 'pr_core_scan_now' ) ) {
+			wp_send_json_error( 'Invalid nonce' );
+		}
+
+		// Verify capability.
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( 'Unauthorized' );
+		}
+
+		// Run scan.
+		PR_Core_Verification_Scanner::run_scan();
+
+		wp_send_json_success( [ 'message' => 'Scan complete' ] );
+	}
+}

--- a/includes/admin/class-pr-core-settings.php
+++ b/includes/admin/class-pr-core-settings.php
@@ -2,110 +2,69 @@
 declare(strict_types=1);
 
 /**
- * Settings page for PR Core plugin features.
+ * Settings page for PR Core plugin configuration.
  *
- * What: Registers admin menu, renders settings form, and handles option saves
- *       for features like Related Articles.
- * Who calls it: PR_Core_Admin::register_hooks().
- * Dependencies: None (reads/writes wp_options).
+ * What: Static admin settings class. Registers and renders the PR Core settings
+ *       page under Peptides, with sections for Related Articles and Verification.
+ * Who calls it: PR_Core::init() via admin_menu and admin_init hooks.
+ * Dependencies: PR_Core_Peptide_CPT (for CAPABILITY constant).
+ *
+ * @see class-pr-core.php — Registers admin_menu + admin_init hooks pointing here.
  */
 class PR_Core_Settings {
 
+	/** @var string Option group shared by all PR Core settings. */
+	public const OPTION_GROUP = 'pr_core_settings';
+
 	/** @var string Option key: enable/disable related articles. */
-	private const ENABLED_OPTION = 'pr_core_related_posts_enabled';
+	private const RELATED_ENABLED = 'pr_core_related_posts_enabled';
 
 	/** @var string Option key: related articles limit (1-6). */
-	private const LIMIT_OPTION = 'pr_core_related_posts_limit';
+	private const RELATED_LIMIT = 'pr_core_related_posts_limit';
+
+	/** @var string Option key: WP-cron scan cadence. */
+	private const SCAN_CADENCE = 'pr_core_scan_cadence';
+
+	/** @var string Option key: default staleness threshold in days. */
+	private const DEFAULT_THRESHOLD = 'pr_core_default_threshold';
+
+	/** @var string Option key: high-velocity staleness threshold in days. */
+	private const HIGH_VELOCITY_THRESHOLD = 'pr_core_high_velocity_threshold';
+
+	/** @var string Option key: comma-separated notification email list. */
+	private const VERIFICATION_EMAIL = 'pr_core_verification_email';
 
 	/**
-	 * Register admin page and settings hooks.
+	 * Register the settings submenu page under Peptides.
+	 *
+	 * Side effects: calls add_submenu_page().
 	 *
 	 * @return void
 	 */
-	public function register_hooks(): void {
-		add_action( 'admin_menu', [ $this, 'add_settings_page' ] );
-		add_action( 'admin_init', [ $this, 'register_settings' ] );
-	}
-
-	/**
-	 * Add submenu page under Peptides.
-	 *
-	 * @return void
-	 */
-	public function add_settings_page(): void {
+	public static function add_settings_page(): void {
 		add_submenu_page(
 			'edit.php?post_type=' . PR_Core_Peptide_CPT::POST_TYPE,
 			__( 'PR Core Settings', 'peptide-repo-core' ),
 			__( 'Settings', 'peptide-repo-core' ),
 			'manage_options',
 			'pr-core-settings',
-			[ $this, 'render_page' ]
+			[ __CLASS__, 'render_page' ]
 		);
 	}
 
 	/**
-	 * Register settings fields.
+	 * Render the settings page form.
 	 *
 	 * @return void
 	 */
-	public function register_settings(): void {
-		register_setting(
-			'pr_core_settings',
-			self::ENABLED_OPTION,
-			[
-				'type'              => 'boolean',
-				'default'           => true,
-				'sanitize_callback' => 'rest_sanitize_boolean',
-			]
-		);
-
-		register_setting(
-			'pr_core_settings',
-			self::LIMIT_OPTION,
-			[
-				'type'              => 'integer',
-				'default'           => 3,
-				'sanitize_callback' => [ $this, 'sanitize_limit' ],
-			]
-		);
-
-		add_settings_section(
-			'pr_core_related_articles',
-			__( 'Related Articles', 'peptide-repo-core' ),
-			[ $this, 'render_section' ],
-			'pr_core_settings'
-		);
-
-		add_settings_field(
-			self::ENABLED_OPTION,
-			__( 'Enable Related Articles', 'peptide-repo-core' ),
-			[ $this, 'render_enabled_field' ],
-			'pr_core_settings',
-			'pr_core_related_articles'
-		);
-
-		add_settings_field(
-			self::LIMIT_OPTION,
-			__( 'Number of Articles to Display', 'peptide-repo-core' ),
-			[ $this, 'render_limit_field' ],
-			'pr_core_settings',
-			'pr_core_related_articles'
-		);
-	}
-
-	/**
-	 * Render the settings page.
-	 *
-	 * @return void
-	 */
-	public function render_page(): void {
+	public static function render_page(): void {
 		?>
 		<div class="wrap">
-			<h1><?php esc_html_e( 'Peptide Repo Core Settings', 'peptide-repo-core' ); ?></h1>
+			<h1><?php esc_html_e( 'PR Core Settings', 'peptide-repo-core' ); ?></h1>
 			<form method="post" action="options.php">
 				<?php
-				settings_fields( 'pr_core_settings' );
-				do_settings_sections( 'pr_core_settings' );
+				settings_fields( self::OPTION_GROUP );
+				do_settings_sections( self::OPTION_GROUP );
 				submit_button();
 				?>
 			</form>
@@ -114,63 +73,159 @@ class PR_Core_Settings {
 	}
 
 	/**
-	 * Render section description.
+	 * Register all settings, sections, and fields on admin_init.
+	 *
+	 * Side effects: calls register_setting(), add_settings_section(),
+	 *               add_settings_field(), add_action() for cron reschedule.
 	 *
 	 * @return void
 	 */
-	public function render_section(): void {
-		echo '<p>' . esc_html__( 'Configure the Related Articles section that appears on peptide single pages.', 'peptide-repo-core' ) . '</p>';
+	public static function register_settings(): void {
+		self::register_related_articles_section();
+		self::register_verification_section();
+		add_action( 'update_option_' . self::SCAN_CADENCE, [ __CLASS__, 'reschedule_cron' ], 10, 2 );
 	}
 
+	// ── Related Articles ─────────────────────────────────────────────────
+
 	/**
-	 * Render enabled toggle field.
+	 * Register Related Articles settings.
 	 *
 	 * @return void
 	 */
-	public function render_enabled_field(): void {
-		$checked = (bool) get_option( self::ENABLED_OPTION, true );
-		?>
-		<input
-			type="checkbox"
-			name="<?php echo esc_attr( self::ENABLED_OPTION ); ?>"
-			value="1"
-			<?php checked( $checked, true ); ?>
-		/>
-		<label>
-			<?php esc_html_e( 'Display related articles on peptide pages', 'peptide-repo-core' ); ?>
-		</label>
-		<?php
+	private static function register_related_articles_section(): void {
+		register_setting( self::OPTION_GROUP, self::RELATED_ENABLED, [ 'type' => 'boolean', 'default' => true,    'sanitize_callback' => 'rest_sanitize_boolean' ] );
+		register_setting( self::OPTION_GROUP, self::RELATED_LIMIT,   [ 'type' => 'integer', 'default' => 3,       'sanitize_callback' => [ __CLASS__, 'sanitize_limit' ] ] );
+
+		add_settings_section( 'pr_core_related_articles', __( 'Related Articles', 'peptide-repo-core' ), '__return_false', self::OPTION_GROUP );
+		add_settings_field( self::RELATED_ENABLED, __( 'Enable Related Articles', 'peptide-repo-core' ), [ __CLASS__, 'render_enabled_field' ], self::OPTION_GROUP, 'pr_core_related_articles' );
+		add_settings_field( self::RELATED_LIMIT,   __( 'Number of Articles',      'peptide-repo-core' ), [ __CLASS__, 'render_limit_field'   ], self::OPTION_GROUP, 'pr_core_related_articles' );
+	}
+
+	/** @return void */
+	public static function render_enabled_field(): void {
+		$enabled = (bool) get_option( self::RELATED_ENABLED, true );
+		printf(
+			'<input type="checkbox" name="%s" value="1"%s /> %s',
+			esc_attr( self::RELATED_ENABLED ),
+			checked( $enabled, true, false ),
+			esc_html__( 'Show related monographs on single peptide pages', 'peptide-repo-core' )
+		);
+	}
+
+	/** @return void */
+	public static function render_limit_field(): void {
+		printf(
+			'<input type="number" name="%s" value="%d" min="1" max="6" />',
+			esc_attr( self::RELATED_LIMIT ),
+			absint( get_option( self::RELATED_LIMIT, 3 ) )
+		);
+		echo '<p class="description">' . esc_html__( 'Number of articles to display (1-6). Default: 3.', 'peptide-repo-core' ) . '</p>';
 	}
 
 	/**
-	 * Render limit field.
-	 *
-	 * @return void
-	 */
-	public function render_limit_field(): void {
-		$limit = (int) get_option( self::LIMIT_OPTION, 3 );
-		?>
-		<input
-			type="number"
-			name="<?php echo esc_attr( self::LIMIT_OPTION ); ?>"
-			value="<?php echo esc_attr( (string) $limit ); ?>"
-			min="1"
-			max="6"
-		/>
-		<p class="description">
-			<?php esc_html_e( 'Number of articles to display (1-6). Default: 3.', 'peptide-repo-core' ); ?>
-		</p>
-		<?php
-	}
-
-	/**
-	 * Sanitize limit to 1-6 range.
+	 * Sanitize the related articles limit to 1-6.
 	 *
 	 * @param mixed $value Raw input.
-	 * @return int Sanitized value.
+	 * @return int
 	 */
-	public function sanitize_limit( $value ): int {
-		$limit = (int) $value;
-		return min( 6, max( 1, $limit ) );
+	public static function sanitize_limit( $value ): int {
+		return min( 6, max( 1, (int) $value ) );
+	}
+
+	// ── Verification ─────────────────────────────────────────────────────
+
+	/**
+	 * Register Verification settings.
+	 *
+	 * @return void
+	 */
+	private static function register_verification_section(): void {
+		register_setting( self::OPTION_GROUP, self::SCAN_CADENCE,            [ 'type' => 'string',  'default' => 'weekly', 'sanitize_callback' => [ __CLASS__, 'sanitize_cadence' ] ] );
+		register_setting( self::OPTION_GROUP, self::DEFAULT_THRESHOLD,       [ 'type' => 'integer', 'default' => 180,      'sanitize_callback' => 'absint' ] );
+		register_setting( self::OPTION_GROUP, self::HIGH_VELOCITY_THRESHOLD, [ 'type' => 'integer', 'default' => 60,       'sanitize_callback' => 'absint' ] );
+		register_setting( self::OPTION_GROUP, self::VERIFICATION_EMAIL,      [ 'type' => 'string',  'default' => '',       'sanitize_callback' => [ __CLASS__, 'sanitize_emails' ] ] );
+
+		add_settings_section( 'pr_core_verification', __( 'Verification', 'peptide-repo-core' ), [ __CLASS__, 'render_verification_section' ], self::OPTION_GROUP );
+		add_settings_field( self::SCAN_CADENCE,            __( 'Scan cadence',                       'peptide-repo-core' ), [ __CLASS__, 'render_cadence_field'       ], self::OPTION_GROUP, 'pr_core_verification' );
+		add_settings_field( self::DEFAULT_THRESHOLD,       __( 'Default staleness threshold (days)',  'peptide-repo-core' ), [ __CLASS__, 'render_threshold_field'     ], self::OPTION_GROUP, 'pr_core_verification' );
+		add_settings_field( self::HIGH_VELOCITY_THRESHOLD, __( 'High-velocity threshold (days)',      'peptide-repo-core' ), [ __CLASS__, 'render_high_velocity_field' ], self::OPTION_GROUP, 'pr_core_verification' );
+		add_settings_field( self::VERIFICATION_EMAIL,      __( 'Notification email(s)',               'peptide-repo-core' ), [ __CLASS__, 'render_email_field'         ], self::OPTION_GROUP, 'pr_core_verification' );
+	}
+
+	/** @return void */
+	public static function render_verification_section(): void {
+		echo '<p>' . esc_html__( 'Configure automatic staleness scanning and digest notifications.', 'peptide-repo-core' ) . '</p>';
+	}
+
+	/** @return void */
+	public static function render_cadence_field(): void {
+		$current = get_option( self::SCAN_CADENCE, 'weekly' );
+		echo '<select name="' . esc_attr( self::SCAN_CADENCE ) . '">';
+		foreach ( [ 'daily' => 'Daily', 'weekly' => 'Weekly', 'monthly' => 'Monthly' ] as $val => $label ) {
+			printf( '<option value="%s"%s>%s</option>', esc_attr( $val ), selected( $current, $val, false ), esc_html( $label ) );
+		}
+		echo '</select>';
+	}
+
+	/** @return void */
+	public static function render_threshold_field(): void {
+		printf( '<input type="number" name="%s" value="%d" min="1" />', esc_attr( self::DEFAULT_THRESHOLD ), absint( get_option( self::DEFAULT_THRESHOLD, 180 ) ) );
+	}
+
+	/** @return void */
+	public static function render_high_velocity_field(): void {
+		printf( '<input type="number" name="%s" value="%d" min="1" />', esc_attr( self::HIGH_VELOCITY_THRESHOLD ), absint( get_option( self::HIGH_VELOCITY_THRESHOLD, 60 ) ) );
+	}
+
+	/** @return void */
+	public static function render_email_field(): void {
+		printf(
+			'<input type="text" name="%s" value="%s" class="regular-text" placeholder="admin@example.com" />',
+			esc_attr( self::VERIFICATION_EMAIL ),
+			esc_attr( (string) get_option( self::VERIFICATION_EMAIL, '' ) )
+		);
+		echo '<p class="description">' . esc_html__( 'Comma-separated. Leave blank to disable email digests.', 'peptide-repo-core' ) . '</p>';
+	}
+
+	/**
+	 * Sanitize cadence to allowed WP-cron recurrence values.
+	 *
+	 * @param string $value Raw input.
+	 * @return string
+	 */
+	public static function sanitize_cadence( string $value ): string {
+		return in_array( $value, [ 'daily', 'weekly', 'monthly' ], true ) ? $value : 'weekly';
+	}
+
+	/**
+	 * Sanitize comma-separated email list, keeping only valid addresses.
+	 *
+	 * @param string $value Raw input.
+	 * @return string
+	 */
+	public static function sanitize_emails( string $value ): string {
+		if ( '' === $value ) {
+			return '';
+		}
+		$valid = array_filter( array_map( 'trim', explode( ',', $value ) ), 'is_email' );
+		return implode( ', ', $valid );
+	}
+
+	/**
+	 * Reschedule the verification cron when cadence changes.
+	 *
+	 * Fires on: update_option_pr_core_scan_cadence.
+	 *
+	 * @param mixed $old_value Previous option value.
+	 * @param mixed $new_value New option value.
+	 * @return void
+	 */
+	public static function reschedule_cron( $old_value, $new_value ): void {
+		if ( $old_value === $new_value ) {
+			return;
+		}
+		wp_clear_scheduled_hook( 'pr_core_verification_scan' );
+		wp_schedule_event( time(), (string) $new_value, 'pr_core_verification_scan' );
 	}
 }

--- a/includes/admin/class-pr-core-verification-metabox.php
+++ b/includes/admin/class-pr-core-verification-metabox.php
@@ -1,0 +1,91 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Verification status meta box for peptide edit screen.
+ *
+ * What: Renders and saves verification status sidebar meta box.
+ * Who calls it: PR_Core_Admin via add_meta_boxes and save_post hooks.
+ * Dependencies: None.
+ *
+ * @see admin/class-pr-core-peptide-metaboxes.php — Other edit-screen meta boxes.
+ */
+class PR_Core_Verification_Metabox {
+
+	/**
+	 * Register the verification meta box.
+	 *
+	 * @return void
+	 */
+	public static function register(): void {
+		add_meta_box(
+			'pr-core-verification',
+			__( 'Verification Status', 'peptide-repo-core' ),
+			[ __CLASS__, 'render' ],
+			PR_Core_Peptide_CPT::POST_TYPE,
+			'side',
+			'default'
+		);
+	}
+
+	/**
+	 * Render the verification status meta box (sidebar).
+	 *
+	 * @param \WP_Post $post Current post.
+	 * @return void
+	 */
+	public static function render( \WP_Post $post ): void {
+		wp_nonce_field( 'pr_core_verification_nonce', 'pr_core_verification_nonce' );
+
+		$last_verified = get_post_meta( $post->ID, '_pr_last_source_verified', true );
+		$velocity      = get_post_meta( $post->ID, '_pr_verification_velocity', true ) ?: 'medium';
+		$status        = get_post_meta( $post->ID, '_pr_verification_status', true ) ?: 'current';
+		$notes         = get_post_meta( $post->ID, '_pr_verification_notes', true ) ?: '';
+
+		echo '<p><strong>' . esc_html__( 'Last Verified', 'peptide-repo-core' ) . ':</strong><br />';
+		echo '<code style="color: #666;">' . esc_html( $last_verified ?: '—' ) . '</code></p>';
+
+		echo '<p><strong>' . esc_html__( 'Verification Velocity', 'peptide-repo-core' ) . ':</strong><br />';
+		echo '<select name="pr_core__pr_verification_velocity" style="width:100%;">';
+		foreach ( [ 'low' => 'Low', 'medium' => 'Medium', 'high' => 'High' ] as $val => $label ) {
+			printf(
+				'<option value="%s"%s>%s</option>',
+				esc_attr( $val ),
+				selected( $velocity, $val, false ),
+				esc_html( $label )
+			);
+		}
+		echo '</select></p>';
+
+		echo '<p><strong>' . esc_html__( 'Status', 'peptide-repo-core' ) . ':</strong><br />';
+		$badge_class = match( $status ) {
+			'due' => 'style="background:#ff9800;color:white;padding:4px 8px;border-radius:3px;"',
+			'overdue' => 'style="background:#f44336;color:white;padding:4px 8px;border-radius:3px;"',
+			default => 'style="background:#4caf50;color:white;padding:4px 8px;border-radius:3px;"',
+		};
+		echo '<span ' . $badge_class . '>' . esc_html( ucfirst( $status ) ) . '</span></p>';
+
+		echo '<p><strong>' . esc_html__( 'Verification Notes', 'peptide-repo-core' ) . ':</strong><br />';
+		printf(
+			'<textarea name="pr_core__pr_verification_notes" rows="3" style="width:100%;">%s</textarea>',
+			esc_textarea( $notes )
+		);
+		echo '</p>';
+
+		echo '<button type="button" class="button button-primary" id="pr-core-mark-verified">' . esc_html__( 'Mark Verified Today', 'peptide-repo-core' ) . '</button>';
+
+		echo '<script>
+		document.getElementById("pr-core-mark-verified").addEventListener("click", function() {
+			const data = new FormData();
+			data.append("action", "pr_core_mark_verified");
+			data.append("post_id", ' . (int) $post->ID . ');
+			data.append("nonce", document.querySelector("[name=\'_wpnonce\']").value);
+			data.append("notes", document.querySelector("[name=\'pr_core__pr_verification_notes\']").value);
+			fetch(ajaxurl, { method: "POST", body: data })
+				.then(r => r.json())
+				.then(d => { if(d.success) { location.reload(); } else { alert("Error: " + (d.data || "Unknown")); }})
+				.catch(e => { alert("Error: " + e); });
+		});
+		</script>';
+	}
+}

--- a/includes/admin/class-pr-core-verification-widget.php
+++ b/includes/admin/class-pr-core-verification-widget.php
@@ -1,0 +1,113 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Dashboard widget for verification status overview.
+ *
+ * What: WordPress dashboard widget showing peptides needing review (due/overdue).
+ * Who calls it: PR_Core::init() hooks wp_dashboard_setup.
+ * Dependencies: PR_Core_Peptide_Repository.
+ *
+ * @see scanner/class-pr-core-verification-scanner.php — Computes status via run_scan().
+ */
+class PR_Core_Verification_Widget {
+
+	/**
+	 * Register the dashboard widget.
+	 *
+	 * Side effects: Registers WP dashboard widget.
+	 *
+	 * @return void
+	 */
+	public static function register(): void {
+		wp_add_dashboard_widget(
+			'pr_core_verification_status',
+			__( 'Monographs Needing Review', 'peptide-repo-core' ),
+			[ __CLASS__, 'render' ]
+		);
+	}
+
+	/**
+	 * Render the widget content.
+	 *
+	 * @return void
+	 */
+	public static function render(): void {
+		$repo = new PR_Core_Peptide_Repository();
+		$peptides = $repo->find_all( [ 'status' => 'publish' ] );
+
+		$due_overdue = [];
+
+		foreach ( $peptides as $dto ) {
+			$status = get_post_meta( $dto->id, '_pr_verification_status', true ) ?: 'current';
+
+			if ( in_array( $status, [ 'due', 'overdue' ], true ) ) {
+				$last_verified = get_post_meta( $dto->id, '_pr_last_source_verified', true );
+				$days_since    = $last_verified
+					? (int) ( ( time() - strtotime( $last_verified ) ) / DAY_IN_SECONDS )
+					: 999;
+
+				$due_overdue[] = [
+					'id'           => $dto->id,
+					'title'        => $dto->title,
+					'status'       => $status,
+					'velocity'     => get_post_meta( $dto->id, '_pr_verification_velocity', true ) ?: 'medium',
+					'last_verified' => $last_verified,
+					'days_since'   => $days_since,
+				];
+			}
+		}
+
+		// Sort by days_since descending (most overdue first).
+		usort( $due_overdue, static function ( $a, $b ) {
+			return $b['days_since'] <=> $a['days_since'];
+		} );
+
+		if ( empty( $due_overdue ) ) {
+			echo '<p>' . esc_html__( 'All monographs are current. ', 'peptide-repo-core' );
+			echo esc_html__( 'Next scan: ', 'peptide-repo-core' );
+			$next = wp_next_scheduled( 'pr_core_verification_scan' );
+			if ( $next ) {
+				echo esc_html( wp_date( 'Y-m-d H:i:s', $next ) );
+			} else {
+				echo esc_html__( '(not scheduled)', 'peptide-repo-core' );
+			}
+			echo '</p>';
+		} else {
+			echo '<table class="widefat striped"><thead><tr>';
+			echo '<th>' . esc_html__( 'Title', 'peptide-repo-core' ) . '</th>';
+			echo '<th>' . esc_html__( 'Verdict', 'peptide-repo-core' ) . '</th>';
+			echo '<th>' . esc_html__( 'Velocity', 'peptide-repo-core' ) . '</th>';
+			echo '<th>' . esc_html__( 'Last Verified', 'peptide-repo-core' ) . '</th>';
+			echo '<th>' . esc_html__( 'Days Overdue', 'peptide-repo-core' ) . '</th>';
+			echo '<th></th>';
+			echo '</tr></thead><tbody>';
+
+			foreach ( $due_overdue as $item ) {
+				$edit_url = get_edit_post_link( $item['id'] );
+				printf(
+					'<tr><td><a href="%s">%s</a></td><td><span class="badge badge-%s">%s</span></td><td>%s</td><td>%s</td><td>%d</td><td><a href="%s" class="button button-small">Edit</a></td></tr>',
+					esc_url( get_permalink( $item['id'] ) ),
+					esc_html( $item['title'] ),
+					esc_attr( $item['status'] ),
+					esc_html( ucfirst( $item['status'] ) ),
+					esc_html( ucfirst( $item['velocity'] ) ),
+					esc_html( $item['last_verified'] ?? '—' ),
+					$item['days_since'],
+					esc_url( $edit_url )
+				);
+			}
+
+			echo '</tbody></table>';
+		}
+
+		echo '<p>';
+		$nonce = wp_create_nonce( 'pr_core_scan_now' );
+		printf(
+			'<form method="post" style="display:inline;"><input type="hidden" name="action" value="pr_core_scan_now" /><input type="hidden" name="nonce" value="%s" /><button type="submit" class="button button-primary">%s</button></form>',
+			esc_attr( $nonce ),
+			esc_html__( 'Scan Now', 'peptide-repo-core' )
+		);
+		echo '</p>';
+	}
+}

--- a/includes/class-pr-core-deactivator.php
+++ b/includes/class-pr-core-deactivator.php
@@ -21,6 +21,10 @@ class PR_Core_Deactivator {
 	 * @return void
 	 */
 	public static function deactivate(): void {
+		// Clear verification scan cron.
+		wp_clear_scheduled_hook( 'pr_core_verification_scan' );
+
+		// Flush rewrite rules.
 		flush_rewrite_rules();
 	}
 }

--- a/includes/class-pr-core.php
+++ b/includes/class-pr-core.php
@@ -41,13 +41,30 @@ class PR_Core {
 		// without a deactivate/reactivate cycle (e.g., SCP/rsync pushes).
 		add_action( 'init', [ PR_Core_Activator::class, 'maybe_flush_on_version_change' ], 999 );
 
+		// Verification scanner: register cron hook and schedule if not already scheduled.
+		if ( ! wp_next_scheduled( 'pr_core_verification_scan' ) ) {
+			wp_schedule_event( time(), get_option( 'pr_core_scan_cadence', 'weekly' ), 'pr_core_verification_scan' );
+		}
+		add_action( 'pr_core_verification_scan', [ PR_Core_Verification_Scanner::class, 'run_scan' ] );
+
+		// Ajax handlers must be registered outside is_admin() — admin-ajax.php
+		// does not define WP_ADMIN, so is_admin() returns false for ajax requests.
+		add_action( 'wp_ajax_pr_core_mark_verified', [ PR_Core_Ajax_Handlers::class, 'handle_mark_verified' ] );
+		add_action( 'wp_ajax_pr_core_scan_now',      [ PR_Core_Ajax_Handlers::class, 'handle_scan_now' ] );
+
 		// Admin UI (fires on admin_init, admin_menu).
 		if ( is_admin() ) {
+			add_action( 'admin_menu', [ PR_Core_Settings::class, 'add_settings_page' ] );
+			add_action( 'admin_init', [ PR_Core_Settings::class, 'register_settings' ] );
+			add_action( 'wp_dashboard_setup', [ PR_Core_Verification_Widget::class, 'register' ] );
+
 			$admin = new PR_Core_Admin();
 			$admin->register_hooks();
 		}
 
-		// Frontend: disclaimer shortcode + JSON-LD.
+		// Frontend: disclaimer shortcode + JSON-LD + verification display.
+		PR_Core_Verification_Display::init();
+
 		$disclaimer = new PR_Core_Disclaimer();
 		$disclaimer->register_hooks();
 

--- a/includes/cpt/class-pr-core-peptide-cpt.php
+++ b/includes/cpt/class-pr-core-peptide-cpt.php
@@ -2,22 +2,18 @@
 declare(strict_types=1);
 
 /**
- * Registers the peptide custom post type and associated taxonomies.
+ * Registers the peptide custom post type and associated taxonomy.
  *
- * What: Defines the peptide CPT with REST support, archive, and monograph meta fields.
- *       Also registers the peptide_category taxonomy (for peptide categorization).
+ * What: Defines peptide CPT with REST support, archive, and meta fields.
  * Who calls it: PR_Core::init() on plugins_loaded.
  * Dependencies: None.
  *
- * Ownership: As of v0.2.0, PR Core is the canonical owner of the `peptide` CPT
- * and `peptide_category` taxonomy (previously registered by Peptide Search AI
- * pre-schema-sprint; PSA v4.5.0 drops its registrations in favor of this one).
- * Registration is guarded by `post_type_exists()` / `taxonomy_exists()` so
- * deploy order between the two plugins does not matter — whichever runs first
- * wins, the other no-ops.
+ * Ownership: As of v0.2.0, PR Core owns the `peptide` CPT and `peptide_category` taxonomy
+ * (previously PSA v4.5.0). Registration guarded by post_type_exists/taxonomy_exists
+ * so deploy order does not matter.
  *
- * @see ARCHITECTURE.md — CPT specification and post-meta field definitions.
- * @see CONVENTIONS.md — CPT ownership rule (no plugin registers a CPT another plugin owns).
+ * @see ARCHITECTURE.md
+ * @see CONVENTIONS.md
  */
 class PR_Core_Peptide_CPT {
 
@@ -119,6 +115,36 @@ class PR_Core_Peptide_CPT {
 				'default'  => 0,
 				'sanitize' => 'absint',
 			],
+			'_pr_last_source_verified' => [
+				'type'     => 'string',
+				'default'  => '',
+				'sanitize' => 'sanitize_text_field',
+			],
+			'_pr_last_reviewed'        => [
+				'type'     => 'string',
+				'default'  => '',
+				'sanitize' => 'sanitize_text_field',
+			],
+			'_pr_next_review_by'       => [
+				'type'     => 'string',
+				'default'  => '',
+				'sanitize' => 'sanitize_text_field',
+			],
+			'_pr_verification_velocity' => [
+				'type'     => 'string',
+				'default'  => 'medium',
+				'sanitize' => [ PR_Core_Verification_Sanitizers::class, 'sanitize_velocity' ],
+			],
+			'_pr_verification_notes'    => [
+				'type'     => 'string',
+				'default'  => '',
+				'sanitize' => 'sanitize_textarea_field',
+			],
+			'_pr_verification_status'   => [
+				'type'     => 'string',
+				'default'  => 'current',
+				'sanitize' => [ PR_Core_Verification_Sanitizers::class, 'sanitize_status' ],
+			],
 		];
 	}
 
@@ -164,17 +190,8 @@ class PR_Core_Peptide_CPT {
 			'menu_name'          => __( 'Peptides', 'peptide-repo-core' ),
 		];
 
-		/*
-		 * Args are a harmonized superset of PR Core's prior `pr_peptide` args
-		 * and PSA's `peptide` args, so the 89 existing posts (authored under
-		 * PSA's registration) keep every capability they relied on:
-		 *   - supports: union of both — thumbnail comes from PSA, revisions +
-		 *     custom-fields come from PR Core.
-		 *   - capability_type + map_meta_cap: preserve PSA's per-role perms.
-		 *   - rewrite slug `peptides`: unchanged from both plugins, so
-		 *     /peptides/%postname%/ URLs keep working and theme templates
-		 *     single-peptide.php / archive-peptide.php continue to match.
-		 */
+		// Args harmonized superset of PR Core + PSA for 89 existing posts.
+		// Supports union, capability/role perms preserved, slugs unchanged.
 		$args = [
 			'labels'             => $labels,
 			'public'             => true,
@@ -184,8 +201,10 @@ class PR_Core_Peptide_CPT {
 			'show_in_nav_menus'  => true,
 			'show_in_rest'       => true,
 			'rest_base'          => 'peptides',
-			// 'rest_namespace' omitted — custom namespaces break Gutenberg
-			// (it fetches wp/v2 hardcoded). WordPress defaults to wp/v2. (#5)
+			// Note: 'rest_namespace' is deliberately omitted. Custom namespaces prevent
+			// Gutenberg's block editor from loading posts for editing (it fetches the
+			// hardcoded wp/v2 REST route). WordPress defaults to wp/v2 — appropriate for
+			// this CPT — and keeps the REST endpoint at /wp-json/wp/v2/peptides/.
 			'menu_position'      => 25,
 			'menu_icon'          => 'dashicons-database',
 			'capability_type'    => 'post',
@@ -195,7 +214,6 @@ class PR_Core_Peptide_CPT {
 			'rewrite'            => [ 'slug' => 'peptides', 'with_front' => false ],
 			'supports'           => [ 'title', 'editor', 'thumbnail', 'excerpt', 'revisions', 'custom-fields' ],
 		];
-
 		register_post_type( self::POST_TYPE, $args );
 	}
 
@@ -203,36 +221,35 @@ class PR_Core_Peptide_CPT {
 	 * Register the `peptide_category` taxonomy.
 	 *
 	 * Guarded with `taxonomy_exists()` for the same reason CPT registration
-	 * is guarded. The 8 existing category terms + term_relationships stay intact —
+	 * is guarded. The 8 existing terms + term_relationships stay intact —
 	 * they key on taxonomy name `peptide_category` in wp_term_taxonomy,
 	 * which is exactly what we register here.
 	 *
 	 * v0.2.0: `pr_peptide_family` taxonomy removed — never populated, never
 	 * surfaced in UI.
 	 *
-	 * v0.3.0: `peptide_topic` taxonomy moved to PR_Core_Topic_Taxonomy class.
-	 *
 	 * Side effects: registers taxonomy with WordPress.
 	 *
 	 * @return void
 	 */
 	public static function register_taxonomies(): void {
-		// Register peptide_category taxonomy.
-		if ( ! taxonomy_exists( self::TAX_CATEGORY ) ) {
-			register_taxonomy( self::TAX_CATEGORY, self::POST_TYPE, [
-				'labels'             => [
-					'name'          => __( 'Peptide Categories', 'peptide-repo-core' ),
-					'singular_name' => __( 'Peptide Category', 'peptide-repo-core' ),
-				],
-				'public'             => true,
-				'publicly_queryable' => true,
-				'show_in_rest'       => true,
-				'show_ui'            => true,
-				'show_admin_column'  => true,
-				'hierarchical'       => true,
-				'rewrite'            => [ 'slug' => 'peptide-category', 'with_front' => false ],
-			] );
+		if ( taxonomy_exists( self::TAX_CATEGORY ) ) {
+			return;
 		}
+
+		register_taxonomy( self::TAX_CATEGORY, self::POST_TYPE, [
+			'labels'             => [
+				'name'          => __( 'Peptide Categories', 'peptide-repo-core' ),
+				'singular_name' => __( 'Peptide Category', 'peptide-repo-core' ),
+			],
+			'public'             => true,
+			'publicly_queryable' => true,
+			'show_in_rest'       => true,
+			'show_ui'            => true,
+			'show_admin_column'  => true,
+			'hierarchical'       => true,
+			'rewrite'            => [ 'slug' => 'peptide-category', 'with_front' => false ],
+		] );
 	}
 
 	/**
@@ -255,12 +272,7 @@ class PR_Core_Peptide_CPT {
 		}
 	}
 
-	/**
-	 * Sanitize a JSON array string (e.g., aliases field).
-	 *
-	 * @param mixed $value Raw input.
-	 * @return string Valid JSON array string.
-	 */
+	/** Sanitize a JSON array string (e.g., aliases field). */
 	public static function sanitize_json_array( $value ): string {
 		if ( is_array( $value ) ) {
 			$value = wp_json_encode( array_map( 'sanitize_text_field', $value ) );
@@ -274,23 +286,13 @@ class PR_Core_Peptide_CPT {
 		return wp_json_encode( array_values( array_map( 'sanitize_text_field', $decoded ) ) );
 	}
 
-	/**
-	 * Sanitize evidence_strength to allowed enum values.
-	 *
-	 * @param mixed $value Raw input.
-	 * @return string Valid enum value.
-	 */
+	/** Sanitize evidence_strength to allowed enum values. */
 	public static function sanitize_evidence_strength( $value ): string {
 		$value = sanitize_text_field( (string) $value );
 		return in_array( $value, self::EVIDENCE_STRENGTHS, true ) ? $value : 'preclinical';
 	}
 
-	/**
-	 * Sanitize editorial_review_status to allowed enum values.
-	 *
-	 * @param mixed $value Raw input.
-	 * @return string Valid enum value.
-	 */
+	/** Sanitize editorial_review_status to allowed enum values. */
 	public static function sanitize_review_status( $value ): string {
 		$value = sanitize_text_field( (string) $value );
 		return in_array( $value, self::REVIEW_STATUSES, true ) ? $value : 'draft';

--- a/includes/cpt/class-pr-core-verification-sanitizers.php
+++ b/includes/cpt/class-pr-core-verification-sanitizers.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Sanitizers for verification meta fields.
+ *
+ * What: Standalone sanitization functions for verification_velocity and verification_status fields.
+ * Who calls it: PR_Core_Peptide_CPT::get_meta_fields() sanitize callbacks.
+ * Dependencies: None.
+ *
+ * @see cpt/class-pr-core-peptide-cpt.php — Calls these from meta field registration.
+ */
+class PR_Core_Verification_Sanitizers {
+
+	/**
+	 * Sanitize verification_velocity to allowed enum values.
+	 *
+	 * @param string $value Raw input.
+	 * @return string Valid enum value (low, medium, high).
+	 */
+	public static function sanitize_velocity( string $value ): string {
+		return in_array( $value, [ 'low', 'medium', 'high' ], true ) ? $value : 'medium';
+	}
+
+	/**
+	 * Sanitize verification_status to allowed enum values.
+	 *
+	 * @param string $value Raw input.
+	 * @return string Valid enum value (current, due, overdue).
+	 */
+	public static function sanitize_status( string $value ): string {
+		return in_array( $value, [ 'current', 'due', 'overdue' ], true ) ? $value : 'current';
+	}
+}

--- a/includes/frontend/class-pr-core-verification-display.php
+++ b/includes/frontend/class-pr-core-verification-display.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Frontend verification date display on peptide single pages.
+ *
+ * What: Appends last-verified date after verdict card on reader-facing pages.
+ * Who calls it: PR_Core::init() hooks the_content filter.
+ * Dependencies: None (hooked via the_content).
+ *
+ * @see includes/class-pr-core.php — Registers the_content hook.
+ */
+class PR_Core_Verification_Display {
+
+	/**
+	 * Initialize frontend hooks.
+	 *
+	 * Side effects: Registers the_content filter.
+	 *
+	 * @return void
+	 */
+	public static function init(): void {
+		add_filter( 'the_content', [ __CLASS__, 'append_verification_display' ], 20 );
+	}
+
+	/**
+	 * Append verification display after verdict card.
+	 *
+	 * @param string $content The post content.
+	 * @return string Modified content.
+	 */
+	public static function append_verification_display( string $content ): string {
+		// Only on peptide CPT, not in admin.
+		if ( is_admin() || ! is_singular( PR_Core_Peptide_CPT::POST_TYPE ) ) {
+			return $content;
+		}
+
+		$post_id = get_the_ID();
+		if ( ! $post_id ) {
+			return $content;
+		}
+
+		// Only if _pr_last_source_verified is set.
+		$last_verified = get_post_meta( $post_id, '_pr_last_source_verified', true );
+		if ( empty( $last_verified ) ) {
+			return $content;
+		}
+
+		// Find the verdict card closing div and append after it.
+		$verdict_close = '</div><!-- .pr-verdict -->';
+		if ( strpos( $content, $verdict_close ) !== false ) {
+			$display = self::render_verification_block( $last_verified );
+			$content = str_replace( $verdict_close, $verdict_close . $display, $content );
+		}
+
+		return $content;
+	}
+
+	/**
+	 * Render the verification block HTML.
+	 *
+	 * @param string $last_verified ISO date string.
+	 * @return string HTML block.
+	 */
+	private static function render_verification_block( string $last_verified ): string {
+		$date_obj = new \DateTime( $last_verified );
+		$formatted_date = $date_obj->format( get_option( 'date_format' ) );
+
+		$html = '<p class="pr-verification-date">';
+		$html .= esc_html__( 'Last verified: ', 'peptide-repo-core' );
+		$html .= sprintf(
+			'<time datetime="%s">%s</time>',
+			esc_attr( $date_obj->format( 'Y-m-d' ) ),
+			esc_html( $formatted_date )
+		);
+		$html .= ' — <a href="' . esc_url( home_url( '/our-methodology/' ) ) . '">' . esc_html__( 'methodology', 'peptide-repo-core' ) . '</a>';
+		$html .= '</p>';
+
+		return $html;
+	}
+}

--- a/includes/scanner/class-pr-core-verification-scanner.php
+++ b/includes/scanner/class-pr-core-verification-scanner.php
@@ -1,0 +1,184 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Verification scanner for peptide monographs.
+ *
+ * What: Runs periodic scans of all published peptides, computes verification status
+ *       (current/due/overdue), logs results, and sends digest notifications.
+ * Who calls it: PR_Core::init() hooks wp_schedule_event; runs via wp_cron.
+ * Dependencies: PR_Core_Peptide_Repository, wp_mail().
+ *
+ * @see admin/class-pr-core-settings.php — Cadence and threshold settings.
+ * @see cpt/class-pr-core-peptide-cpt.php — Verification meta field specs.
+ */
+class PR_Core_Verification_Scanner {
+
+	const DEFAULT_THRESHOLD_DAYS  = 180;
+	const HIGH_VELOCITY_THRESHOLD = 60;
+	const LOW_VELOCITY_THRESHOLD  = 365;
+	const SCAN_LOG_OPTION_KEY     = 'pr_core_verification_scan_log';
+	const MAX_LOG_ENTRIES         = 90;
+
+	/**
+	 * Run verification scan on all published peptides.
+	 *
+	 * Side effects: Updates _pr_verification_status, appends to scan log, sends email.
+	 *
+	 * @return void
+	 */
+	public static function run_scan(): void {
+		$repo = new PR_Core_Peptide_Repository();
+		$peptides = $repo->find_all( [ 'status' => 'publish' ] );
+
+		$due_peptides = [];
+		$overdue_peptides = [];
+
+		foreach ( $peptides as $dto ) {
+			$last_verified = get_post_meta( $dto->id, '_pr_last_source_verified', true );
+			$velocity      = get_post_meta( $dto->id, '_pr_verification_velocity', true ) ?: 'medium';
+
+			// Empty verified date = treat as overdue.
+			if ( empty( $last_verified ) ) {
+				update_post_meta( $dto->id, '_pr_verification_status', 'overdue' );
+				$overdue_peptides[] = $dto;
+				continue;
+			}
+
+			// Compute days since verification.
+			$days_since = ( time() - strtotime( $last_verified ) ) / DAY_IN_SECONDS;
+
+			// Determine threshold based on velocity.
+			$threshold = match ( $velocity ) {
+				'high' => (int) get_option( 'pr_core_high_velocity_threshold', self::HIGH_VELOCITY_THRESHOLD ),
+				'low'  => self::LOW_VELOCITY_THRESHOLD,
+				default => (int) get_option( 'pr_core_default_threshold', self::DEFAULT_THRESHOLD_DAYS ),
+			};
+
+			// Compute status: current if < 90%, due if < 100%, overdue if >= 100%.
+			$status = $days_since < ( $threshold * 0.9 )
+				? 'current'
+				: ( $days_since < $threshold ? 'due' : 'overdue' );
+
+			update_post_meta( $dto->id, '_pr_verification_status', $status );
+
+			if ( 'due' === $status ) {
+				$due_peptides[] = $dto;
+			} elseif ( 'overdue' === $status ) {
+				$overdue_peptides[] = $dto;
+			}
+		}
+
+		// Log the scan result.
+		self::log_scan( count( $peptides ), count( $due_peptides ), count( $overdue_peptides ) );
+
+		// Send digest email if configured and there are items needing review.
+		if ( ! empty( $due_peptides ) || ! empty( $overdue_peptides ) ) {
+			self::send_digest_email( $due_peptides, $overdue_peptides );
+		}
+	}
+
+	/**
+	 * Log scan summary to WP option, keeping last N entries.
+	 *
+	 * @param int $total  Total peptides scanned.
+	 * @param int $due    Count of due peptides.
+	 * @param int $overdue Count of overdue peptides.
+	 * @return void
+	 */
+	private static function log_scan( int $total, int $due, int $overdue ): void {
+		$log = get_option( self::SCAN_LOG_OPTION_KEY, [] );
+		if ( ! is_array( $log ) ) {
+			$log = [];
+		}
+
+		$log[] = [
+			'timestamp' => current_time( 'mysql' ),
+			'total'     => $total,
+			'due'       => $due,
+			'overdue'   => $overdue,
+		];
+
+		// Keep only the last MAX_LOG_ENTRIES.
+		if ( count( $log ) > self::MAX_LOG_ENTRIES ) {
+			$log = array_slice( $log, -self::MAX_LOG_ENTRIES );
+		}
+
+		update_option( self::SCAN_LOG_OPTION_KEY, $log );
+	}
+
+	/**
+	 * Send digest email to configured recipient(s).
+	 *
+	 * @param array<PR_Core_Peptide_DTO> $due_peptides Peptides due for review.
+	 * @param array<PR_Core_Peptide_DTO> $overdue_peptides Peptides overdue for review.
+	 * @return void
+	 */
+	private static function send_digest_email( array $due_peptides, array $overdue_peptides ): void {
+		$recipients = get_option( 'pr_core_verification_email', '' );
+		if ( empty( $recipients ) ) {
+			return;
+		}
+
+		// Parse comma-separated emails.
+		$emails = array_map( 'trim', explode( ',', $recipients ) );
+		$emails = array_filter( $emails, static function ( $email ) {
+			return is_email( $email );
+		} );
+
+		if ( empty( $emails ) ) {
+			return;
+		}
+
+		$subject = sprintf(
+			'[Peptide Repo] Verification digest: %d due, %d overdue',
+			count( $due_peptides ),
+			count( $overdue_peptides )
+		);
+
+		$body = self::build_email_body( $due_peptides, $overdue_peptides );
+
+		wp_mail( $emails, $subject, $body, [ 'Content-Type: text/html; charset=UTF-8' ] );
+	}
+
+	/**
+	 * Build HTML email body for digest.
+	 *
+	 * @param array<PR_Core_Peptide_DTO> $due_peptides Peptides due for review.
+	 * @param array<PR_Core_Peptide_DTO> $overdue_peptides Peptides overdue for review.
+	 * @return string HTML email body.
+	 */
+	private static function build_email_body( array $due_peptides, array $overdue_peptides ): string {
+		$body = '<h2>Verification Digest</h2>';
+
+		if ( ! empty( $overdue_peptides ) ) {
+			$body .= '<h3>Overdue for review (' . count( $overdue_peptides ) . ')</h3><ul>';
+			foreach ( $overdue_peptides as $dto ) {
+				$edit_url = get_edit_post_link( $dto->id );
+				$body .= sprintf(
+					'<li><a href="%s">%s</a></li>',
+					esc_url( $edit_url ),
+					esc_html( $dto->title )
+				);
+			}
+			$body .= '</ul>';
+		}
+
+		if ( ! empty( $due_peptides ) ) {
+			$body .= '<h3>Due for review (' . count( $due_peptides ) . ')</h3><ul>';
+			foreach ( $due_peptides as $dto ) {
+				$edit_url = get_edit_post_link( $dto->id );
+				$body .= sprintf(
+					'<li><a href="%s">%s</a></li>',
+					esc_url( $edit_url ),
+					esc_html( $dto->title )
+				);
+			}
+			$body .= '</ul>';
+		}
+
+		$body .= '<p><a href="' . esc_url( admin_url( 'index.php?page=pr-core-verification' ) ) . '">View verification dashboard</a></p>';
+
+		return $body;
+	}
+}

--- a/includes/scanner/class-pr-core-verification-scanner.php
+++ b/includes/scanner/class-pr-core-verification-scanner.php
@@ -45,20 +45,8 @@ class PR_Core_Verification_Scanner {
 				continue;
 			}
 
-			// Compute days since verification.
-			$days_since = ( time() - strtotime( $last_verified ) ) / DAY_IN_SECONDS;
-
-			// Determine threshold based on velocity.
-			$threshold = match ( $velocity ) {
-				'high' => (int) get_option( 'pr_core_high_velocity_threshold', self::HIGH_VELOCITY_THRESHOLD ),
-				'low'  => self::LOW_VELOCITY_THRESHOLD,
-				default => (int) get_option( 'pr_core_default_threshold', self::DEFAULT_THRESHOLD_DAYS ),
-			};
-
-			// Compute status: current if < 90%, due if < 100%, overdue if >= 100%.
-			$status = $days_since < ( $threshold * 0.9 )
-				? 'current'
-				: ( $days_since < $threshold ? 'due' : 'overdue' );
+			// Delegate to compute_status() — keeps logic testable without DB calls.
+			$status = self::compute_status( $last_verified, $velocity );
 
 			update_post_meta( $dto->id, '_pr_verification_status', $status );
 
@@ -76,6 +64,33 @@ class PR_Core_Verification_Scanner {
 		if ( ! empty( $due_peptides ) || ! empty( $overdue_peptides ) ) {
 			self::send_digest_email( $due_peptides, $overdue_peptides );
 		}
+	}
+
+
+	/**
+	 * Compute verification status for a single peptide.
+	 *
+	 * Extracted for direct unit-testability without database or WP-cron dependencies.
+	 *
+	 * @param string $last_verified YYYY-MM-DD date of last source verification. Empty = overdue.
+	 * @param string $velocity      Velocity tier: high | medium | low.
+	 * @return string Status: current | due | overdue.
+	 */
+	public static function compute_status( string $last_verified, string $velocity ): string {
+		if ( empty( $last_verified ) ) {
+			return 'overdue';
+		}
+
+		$days_since = ( time() - strtotime( $last_verified ) ) / DAY_IN_SECONDS;
+		$threshold  = match ( $velocity ) {
+			'high' => (int) get_option( 'pr_core_high_velocity_threshold', self::HIGH_VELOCITY_THRESHOLD ),
+			'low'  => self::LOW_VELOCITY_THRESHOLD,
+			default => (int) get_option( 'pr_core_default_threshold', self::DEFAULT_THRESHOLD_DAYS ),
+		};
+
+		return $days_since < ( $threshold * 0.9 )
+			? 'current'
+			: ( $days_since < $threshold ? 'due' : 'overdue' );
 	}
 
 	/**

--- a/peptide-repo-core.php
+++ b/peptide-repo-core.php
@@ -3,7 +3,7 @@
  * Plugin Name: Peptide Repo Core
  * Plugin URI:  https://peptiderepo.com
  * Description: Canonical peptide schema — shared data layer for the peptiderepo.com ecosystem. Provides the peptide CPT, dosing rows, legal status cells, AI candidate queue, disclaimer component, and JSON-LD output.
- * Version:     0.3.2
+ * Version:     0.4.0
  * Author:      peptiderepo
  * Author URI:  https://peptiderepo.com
  * License:     GPL-2.0-or-later
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /* ── Constants ────────────────────────────────────────────────────────── */
 
-define( 'PR_CORE_VERSION', '0.3.2' );
+define( 'PR_CORE_VERSION', '0.4.0' );
 define( 'PR_CORE_PLUGIN_FILE', __FILE__ );
 define( 'PR_CORE_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PR_CORE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/tests/unit/test-verification-scanner.php
+++ b/tests/unit/test-verification-scanner.php
@@ -1,134 +1,128 @@
 <?php
+/**
+ * Unit tests for PR_Core_Verification_Scanner::compute_status().
+ *
+ * Run: php tests/unit/test-verification-scanner.php
+ * Exit code 0 = all pass, 1 = any failure.
+ *
+ * What's covered:
+ *   - Empty last_verified → overdue.
+ *   - Days < 90% of threshold → current.
+ *   - Days >= 90% and < 100% of threshold → due.
+ *   - Days >= threshold → overdue.
+ *   - Boundary: exactly at 90% → due (not current).
+ *   - high velocity applies 60-day threshold from option.
+ *   - low velocity applies 365-day constant (not option).
+ *   - medium/default applies 180-day threshold from option.
+ *
+ * @package PeptideRepoCore
+ */
+
 declare(strict_types=1);
 
-/**
- * Tests for PR_Core_Verification_Scanner.
- *
- * What: Unit tests for status computation logic.
- * Dependencies: PHPUnit, WordPress test utilities.
- *
- * Mock strategy: Zero real DB calls — mock get_option() and update_post_meta().
- */
-class Test_Verification_Scanner extends \WP_UnitTestCase {
+require_once __DIR__ . '/../bootstrap.php';
 
-	/**
-	 * Test current status when days_since < threshold * 0.9.
-	 */
-	public function test_status_current(): void {
-		// Days since = 160, threshold = 180, 90% = 162.
-		// 160 < 162 => current.
-		$last_verified = gmdate( 'Y-m-d H:i:s', time() - ( 160 * DAY_IN_SECONDS ) );
+// ── Additional stubs needed by the scanner ──────────────────────────────
 
-		// Mock the repository and post meta.
-		$dto = $this->create_mock_dto( 1, $last_verified, 'medium' );
+if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+	define( 'DAY_IN_SECONDS', 86400 );
+}
 
-		$status = $this->compute_status( $dto, 180, 'medium' );
-		$this->assertEquals( 'current', $status );
-	}
+/** @var array<string, mixed> $GLOBALS['pr_core_options'] Mocked option store. */
+$GLOBALS['pr_core_options'] = [];
 
-	/**
-	 * Test due status when threshold * 0.9 <= days_since < threshold.
-	 */
-	public function test_status_due(): void {
-		// Days since = 170, threshold = 180, 90% = 162.
-		// 162 <= 170 < 180 => due.
-		$last_verified = gmdate( 'Y-m-d H:i:s', time() - ( 170 * DAY_IN_SECONDS ) );
-
-		$dto = $this->create_mock_dto( 2, $last_verified, 'medium' );
-		$status = $this->compute_status( $dto, 180, 'medium' );
-		$this->assertEquals( 'due', $status );
-	}
-
-	/**
-	 * Test overdue status when days_since >= threshold.
-	 */
-	public function test_status_overdue(): void {
-		// Days since = 190, threshold = 180.
-		// 190 >= 180 => overdue.
-		$last_verified = gmdate( 'Y-m-d H:i:s', time() - ( 190 * DAY_IN_SECONDS ) );
-
-		$dto = $this->create_mock_dto( 3, $last_verified, 'medium' );
-		$status = $this->compute_status( $dto, 180, 'medium' );
-		$this->assertEquals( 'overdue', $status );
-	}
-
-	/**
-	 * Test empty verified date => overdue.
-	 */
-	public function test_empty_verified_date_is_overdue(): void {
-		$dto = $this->create_mock_dto( 4, '', 'medium' );
-		$status = $this->compute_status( $dto, 180, 'medium', true );
-		$this->assertEquals( 'overdue', $status );
-	}
-
-	/**
-	 * Test high velocity threshold.
-	 */
-	public function test_high_velocity_threshold(): void {
-		// Days since = 70, high threshold = 60, 90% = 54.
-		// 54 <= 70 => due (not current even with high velocity).
-		$last_verified = gmdate( 'Y-m-d H:i:s', time() - ( 70 * DAY_IN_SECONDS ) );
-
-		$dto = $this->create_mock_dto( 5, $last_verified, 'high' );
-		$status = $this->compute_status( $dto, 60, 'high' );
-		$this->assertEquals( 'due', $status );
-	}
-
-	/**
-	 * Test low velocity threshold.
-	 */
-	public function test_low_velocity_threshold(): void {
-		// Days since = 350, low threshold = 365, 90% = 328.5.
-		// 328.5 < 350 < 365 => due.
-		$last_verified = gmdate( 'Y-m-d H:i:s', time() - ( 350 * DAY_IN_SECONDS ) );
-
-		$dto = $this->create_mock_dto( 6, $last_verified, 'low' );
-		$status = $this->compute_status( $dto, 365, 'low' );
-		$this->assertEquals( 'due', $status );
-	}
-
-	/**
-	 * Create a mock DTO.
-	 *
-	 * @param int    $id Post ID.
-	 * @param string $last_verified Verified date (or empty).
-	 * @param string $velocity Velocity level.
-	 * @return object Mock DTO.
-	 */
-	private function create_mock_dto( int $id, string $last_verified, string $velocity ): object {
-		$dto = new \stdClass();
-		$dto->id = $id;
-		$dto->title = "Test Peptide $id";
-		$dto->excerpt = '';
-		$dto->content = '';
-
-		// Store in post meta for the computation.
-		update_post_meta( $id, '_pr_last_source_verified', $last_verified );
-		update_post_meta( $id, '_pr_verification_velocity', $velocity );
-
-		return $dto;
-	}
-
-	/**
-	 * Compute status using the scanner logic inline (no DB calls beyond meta).
-	 *
-	 * @param object $dto Peptide DTO.
-	 * @param int    $threshold Threshold in days.
-	 * @param string $velocity Velocity level.
-	 * @param bool   $empty_date Whether date is empty.
-	 * @return string Status.
-	 */
-	private function compute_status( object $dto, int $threshold, string $velocity, bool $empty_date = false ): string {
-		$last_verified = get_post_meta( $dto->id, '_pr_last_source_verified', true );
-
-		if ( $empty_date || empty( $last_verified ) ) {
-			return 'overdue';
-		}
-
-		$days_since = ( time() - strtotime( $last_verified ) ) / DAY_IN_SECONDS;
-
-		return $days_since < ( $threshold * 0.9 )
-			? 'current'
-			: ( $days_since < $threshold ? 'due' : 'overdue' );
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( string $key, $default = false ) {
+		return $GLOBALS['pr_core_options'][ $key ] ?? $default;
 	}
 }
+
+// ── Load the scanner class ──────────────────────────────────────────────
+
+require_once __DIR__ . '/../../includes/scanner/class-pr-core-verification-scanner.php';
+
+// ── Helper: build a date N days ago ────────────────────────────────────
+
+function days_ago( int $days ): string {
+	return gmdate( 'Y-m-d', time() - ( $days * DAY_IN_SECONDS ) );
+}
+
+echo "== PR_Core_Verification_Scanner::compute_status() unit tests ==\n\n";
+
+// ── Empty last_verified ─────────────────────────────────────────────────
+
+echo "Empty last_verified:\n";
+pr_assert_equals(
+	'overdue',
+	PR_Core_Verification_Scanner::compute_status( '', 'medium' ),
+	'empty string → overdue'
+);
+
+// ── Medium velocity (default 180-day threshold) ─────────────────────────
+
+echo "\nMedium velocity (threshold=180, option default):\n";
+$GLOBALS['pr_core_options'] = [];
+
+// 160 days ago → 160 < 162 (90% of 180) → current.
+pr_assert_equals( 'current', PR_Core_Verification_Scanner::compute_status( days_ago( 160 ), 'medium' ), '160 days → current' );
+
+// 163 days ago → 163 >= 162 and < 180 → due.
+pr_assert_equals( 'due', PR_Core_Verification_Scanner::compute_status( days_ago( 163 ), 'medium' ), '163 days → due' );
+
+// 180 days ago → 180 >= 180 → overdue.
+pr_assert_equals( 'overdue', PR_Core_Verification_Scanner::compute_status( days_ago( 180 ), 'medium' ), '180 days → overdue' );
+
+// 200 days ago → overdue.
+pr_assert_equals( 'overdue', PR_Core_Verification_Scanner::compute_status( days_ago( 200 ), 'medium' ), '200 days → overdue' );
+
+// ── 90% boundary exactness ──────────────────────────────────────────────
+
+echo "\n90% boundary (threshold=100):\n";
+$GLOBALS['pr_core_options'] = [ 'pr_core_default_threshold' => 100 ];
+
+// 89 days → 89 < 90 (90% of 100) → current.
+pr_assert_equals( 'current', PR_Core_Verification_Scanner::compute_status( days_ago( 89 ), 'medium' ), '89 days (threshold 100) → current' );
+
+// 90 days → 90 >= 90 and < 100 → due.
+pr_assert_equals( 'due', PR_Core_Verification_Scanner::compute_status( days_ago( 90 ), 'medium' ), '90 days (threshold 100) → due (at boundary)' );
+
+// 100 days → 100 >= 100 → overdue.
+pr_assert_equals( 'overdue', PR_Core_Verification_Scanner::compute_status( days_ago( 100 ), 'medium' ), '100 days (threshold 100) → overdue' );
+
+// ── High velocity (60-day threshold from option) ────────────────────────
+
+echo "\nHigh velocity (threshold=60 from option):\n";
+$GLOBALS['pr_core_options'] = [ 'pr_core_high_velocity_threshold' => 60 ];
+
+// 50 days → 50 < 54 (90% of 60) → current.
+pr_assert_equals( 'current', PR_Core_Verification_Scanner::compute_status( days_ago( 50 ), 'high' ), 'high: 50 days → current' );
+
+// 55 days → 55 >= 54, < 60 → due.
+pr_assert_equals( 'due', PR_Core_Verification_Scanner::compute_status( days_ago( 55 ), 'high' ), 'high: 55 days → due' );
+
+// 61 days → overdue.
+pr_assert_equals( 'overdue', PR_Core_Verification_Scanner::compute_status( days_ago( 61 ), 'high' ), 'high: 61 days → overdue' );
+
+// ── Low velocity (365-day constant — ignores option) ────────────────────
+
+echo "\nLow velocity (threshold=365, constant, ignores option):\n";
+$GLOBALS['pr_core_options'] = [ 'pr_core_default_threshold' => 999 ]; // Should be ignored for low.
+
+// 300 days → 300 < 328.5 (90% of 365) → current.
+pr_assert_equals( 'current', PR_Core_Verification_Scanner::compute_status( days_ago( 300 ), 'low' ), 'low: 300 days → current' );
+
+// 340 days → 340 >= 328.5, < 365 → due.
+pr_assert_equals( 'due', PR_Core_Verification_Scanner::compute_status( days_ago( 340 ), 'low' ), 'low: 340 days → due' );
+
+// 366 days → overdue.
+pr_assert_equals( 'overdue', PR_Core_Verification_Scanner::compute_status( days_ago( 366 ), 'low' ), 'low: 366 days → overdue' );
+
+// ── Unknown velocity falls through to medium/default ────────────────────
+
+echo "\nUnknown velocity (falls to default/medium):\n";
+$GLOBALS['pr_core_options'] = [ 'pr_core_default_threshold' => 180 ];
+pr_assert_equals( 'current', PR_Core_Verification_Scanner::compute_status( days_ago( 100 ), 'unknown' ), 'unknown velocity: 100 days → current (uses default 180)' );
+
+// ── Summary ─────────────────────────────────────────────────────────────
+
+exit( pr_test_summary() );

--- a/tests/unit/test-verification-scanner.php
+++ b/tests/unit/test-verification-scanner.php
@@ -1,0 +1,134 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Tests for PR_Core_Verification_Scanner.
+ *
+ * What: Unit tests for status computation logic.
+ * Dependencies: PHPUnit, WordPress test utilities.
+ *
+ * Mock strategy: Zero real DB calls — mock get_option() and update_post_meta().
+ */
+class Test_Verification_Scanner extends \WP_UnitTestCase {
+
+	/**
+	 * Test current status when days_since < threshold * 0.9.
+	 */
+	public function test_status_current(): void {
+		// Days since = 160, threshold = 180, 90% = 162.
+		// 160 < 162 => current.
+		$last_verified = gmdate( 'Y-m-d H:i:s', time() - ( 160 * DAY_IN_SECONDS ) );
+
+		// Mock the repository and post meta.
+		$dto = $this->create_mock_dto( 1, $last_verified, 'medium' );
+
+		$status = $this->compute_status( $dto, 180, 'medium' );
+		$this->assertEquals( 'current', $status );
+	}
+
+	/**
+	 * Test due status when threshold * 0.9 <= days_since < threshold.
+	 */
+	public function test_status_due(): void {
+		// Days since = 170, threshold = 180, 90% = 162.
+		// 162 <= 170 < 180 => due.
+		$last_verified = gmdate( 'Y-m-d H:i:s', time() - ( 170 * DAY_IN_SECONDS ) );
+
+		$dto = $this->create_mock_dto( 2, $last_verified, 'medium' );
+		$status = $this->compute_status( $dto, 180, 'medium' );
+		$this->assertEquals( 'due', $status );
+	}
+
+	/**
+	 * Test overdue status when days_since >= threshold.
+	 */
+	public function test_status_overdue(): void {
+		// Days since = 190, threshold = 180.
+		// 190 >= 180 => overdue.
+		$last_verified = gmdate( 'Y-m-d H:i:s', time() - ( 190 * DAY_IN_SECONDS ) );
+
+		$dto = $this->create_mock_dto( 3, $last_verified, 'medium' );
+		$status = $this->compute_status( $dto, 180, 'medium' );
+		$this->assertEquals( 'overdue', $status );
+	}
+
+	/**
+	 * Test empty verified date => overdue.
+	 */
+	public function test_empty_verified_date_is_overdue(): void {
+		$dto = $this->create_mock_dto( 4, '', 'medium' );
+		$status = $this->compute_status( $dto, 180, 'medium', true );
+		$this->assertEquals( 'overdue', $status );
+	}
+
+	/**
+	 * Test high velocity threshold.
+	 */
+	public function test_high_velocity_threshold(): void {
+		// Days since = 70, high threshold = 60, 90% = 54.
+		// 54 <= 70 => due (not current even with high velocity).
+		$last_verified = gmdate( 'Y-m-d H:i:s', time() - ( 70 * DAY_IN_SECONDS ) );
+
+		$dto = $this->create_mock_dto( 5, $last_verified, 'high' );
+		$status = $this->compute_status( $dto, 60, 'high' );
+		$this->assertEquals( 'due', $status );
+	}
+
+	/**
+	 * Test low velocity threshold.
+	 */
+	public function test_low_velocity_threshold(): void {
+		// Days since = 350, low threshold = 365, 90% = 328.5.
+		// 328.5 < 350 < 365 => due.
+		$last_verified = gmdate( 'Y-m-d H:i:s', time() - ( 350 * DAY_IN_SECONDS ) );
+
+		$dto = $this->create_mock_dto( 6, $last_verified, 'low' );
+		$status = $this->compute_status( $dto, 365, 'low' );
+		$this->assertEquals( 'due', $status );
+	}
+
+	/**
+	 * Create a mock DTO.
+	 *
+	 * @param int    $id Post ID.
+	 * @param string $last_verified Verified date (or empty).
+	 * @param string $velocity Velocity level.
+	 * @return object Mock DTO.
+	 */
+	private function create_mock_dto( int $id, string $last_verified, string $velocity ): object {
+		$dto = new \stdClass();
+		$dto->id = $id;
+		$dto->title = "Test Peptide $id";
+		$dto->excerpt = '';
+		$dto->content = '';
+
+		// Store in post meta for the computation.
+		update_post_meta( $id, '_pr_last_source_verified', $last_verified );
+		update_post_meta( $id, '_pr_verification_velocity', $velocity );
+
+		return $dto;
+	}
+
+	/**
+	 * Compute status using the scanner logic inline (no DB calls beyond meta).
+	 *
+	 * @param object $dto Peptide DTO.
+	 * @param int    $threshold Threshold in days.
+	 * @param string $velocity Velocity level.
+	 * @param bool   $empty_date Whether date is empty.
+	 * @return string Status.
+	 */
+	private function compute_status( object $dto, int $threshold, string $velocity, bool $empty_date = false ): string {
+		$last_verified = get_post_meta( $dto->id, '_pr_last_source_verified', true );
+
+		if ( $empty_date || empty( $last_verified ) ) {
+			return 'overdue';
+		}
+
+		$days_since = ( time() - strtotime( $last_verified ) ) / DAY_IN_SECONDS;
+
+		return $days_since < ( $threshold * 0.9 )
+			? 'current'
+			: ( $days_since < $threshold ? 'due' : 'overdue' );
+	}
+}

--- a/tests/unit/test-verification-settings.php
+++ b/tests/unit/test-verification-settings.php
@@ -1,0 +1,93 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Tests for PR_Core_Settings cadence and cron scheduling.
+ *
+ * What: Unit tests for settings registration and cron rescheduling.
+ * Dependencies: PHPUnit, WordPress test utilities.
+ */
+class Test_Verification_Settings extends \WP_UnitTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		// Clear any existing scheduled hooks.
+		wp_clear_scheduled_hook( 'pr_core_verification_scan' );
+	}
+
+	/**
+	 * Test that changing cadence triggers reschedule.
+	 */
+	public function test_reschedule_on_cadence_change(): void {
+		// Set initial cadence.
+		update_option( 'pr_core_scan_cadence', 'weekly' );
+
+		// Schedule initial cron (simulate the activation).
+		if ( ! wp_next_scheduled( 'pr_core_verification_scan' ) ) {
+			wp_schedule_event( time(), 'weekly', 'pr_core_verification_scan' );
+		}
+
+		// Verify it's scheduled.
+		$scheduled = wp_next_scheduled( 'pr_core_verification_scan' );
+		$this->assertNotFalse( $scheduled );
+
+		// Change the cadence (triggers reschedule via hook).
+		update_option( 'pr_core_scan_cadence', 'daily' );
+
+		// The reschedule_cron method should have cleared and rescheduled.
+		// (In a real test, this would be tested via the hook — here we verify the logic.)
+		PR_Core_Settings::reschedule_cron( 'weekly', 'daily' );
+
+		// Verify cron still exists (just with new frequency).
+		$scheduled = wp_next_scheduled( 'pr_core_verification_scan' );
+		$this->assertNotFalse( $scheduled );
+	}
+
+	/**
+	 * Test that same cadence does not reschedule.
+	 */
+	public function test_no_reschedule_if_unchanged(): void {
+		update_option( 'pr_core_scan_cadence', 'weekly' );
+
+		if ( ! wp_next_scheduled( 'pr_core_verification_scan' ) ) {
+			wp_schedule_event( time(), 'weekly', 'pr_core_verification_scan' );
+		}
+
+		$first_scheduled = wp_next_scheduled( 'pr_core_verification_scan' );
+
+		// Call reschedule with same value.
+		PR_Core_Settings::reschedule_cron( 'weekly', 'weekly' );
+
+		$second_scheduled = wp_next_scheduled( 'pr_core_verification_scan' );
+
+		// Should be unchanged (same cron hook).
+		$this->assertEquals( $first_scheduled, $second_scheduled );
+	}
+
+	/**
+	 * Test cadence sanitization.
+	 */
+	public function test_sanitize_cadence(): void {
+		$this->assertEquals( 'daily', PR_Core_Settings::sanitize_cadence( 'daily' ) );
+		$this->assertEquals( 'weekly', PR_Core_Settings::sanitize_cadence( 'weekly' ) );
+		$this->assertEquals( 'monthly', PR_Core_Settings::sanitize_cadence( 'monthly' ) );
+		$this->assertEquals( 'weekly', PR_Core_Settings::sanitize_cadence( 'invalid' ) );
+	}
+
+	/**
+	 * Test email sanitization.
+	 */
+	public function test_sanitize_emails(): void {
+		$input = 'admin@example.com, editor@example.com';
+		$output = PR_Core_Settings::sanitize_emails( $input );
+		$this->assertStringContainsString( 'admin@example.com', $output );
+		$this->assertStringContainsString( 'editor@example.com', $output );
+
+		// Invalid emails filtered out.
+		$input_bad = 'admin@example.com, invalid-email, editor@example.com';
+		$output = PR_Core_Settings::sanitize_emails( $input_bad );
+		$this->assertStringContainsString( 'admin@example.com', $output );
+		$this->assertStringContainsString( 'editor@example.com', $output );
+		$this->assertStringNotContainsString( 'invalid-email', $output );
+	}
+}

--- a/tests/unit/test-verification-settings.php
+++ b/tests/unit/test-verification-settings.php
@@ -1,93 +1,131 @@
 <?php
+/**
+ * Unit tests for PR_Core_Settings verification methods.
+ *
+ * Run: php tests/unit/test-verification-settings.php
+ * Exit code 0 = all pass, 1 = any failure.
+ *
+ * What's covered:
+ *   - sanitize_cadence() accepts valid values, rejects invalid → 'weekly'.
+ *   - sanitize_emails() filters invalid addresses, preserves valid ones.
+ *   - reschedule_cron() no-ops when old === new value.
+ *   - reschedule_cron() clears + reschedules when value changes.
+ *
+ * @package PeptideRepoCore
+ */
+
 declare(strict_types=1);
 
-/**
- * Tests for PR_Core_Settings cadence and cron scheduling.
- *
- * What: Unit tests for settings registration and cron rescheduling.
- * Dependencies: PHPUnit, WordPress test utilities.
- */
-class Test_Verification_Settings extends \WP_UnitTestCase {
+require_once __DIR__ . '/../bootstrap.php';
 
-	protected function setUp(): void {
-		parent::setUp();
-		// Clear any existing scheduled hooks.
-		wp_clear_scheduled_hook( 'pr_core_verification_scan' );
-	}
+// ── Additional stubs needed by the settings class ───────────────────────
 
-	/**
-	 * Test that changing cadence triggers reschedule.
-	 */
-	public function test_reschedule_on_cadence_change(): void {
-		// Set initial cadence.
-		update_option( 'pr_core_scan_cadence', 'weekly' );
+$GLOBALS['pr_core_options']    = [];
+$GLOBALS['pr_core_cron_calls'] = [];
 
-		// Schedule initial cron (simulate the activation).
-		if ( ! wp_next_scheduled( 'pr_core_verification_scan' ) ) {
-			wp_schedule_event( time(), 'weekly', 'pr_core_verification_scan' );
-		}
-
-		// Verify it's scheduled.
-		$scheduled = wp_next_scheduled( 'pr_core_verification_scan' );
-		$this->assertNotFalse( $scheduled );
-
-		// Change the cadence (triggers reschedule via hook).
-		update_option( 'pr_core_scan_cadence', 'daily' );
-
-		// The reschedule_cron method should have cleared and rescheduled.
-		// (In a real test, this would be tested via the hook — here we verify the logic.)
-		PR_Core_Settings::reschedule_cron( 'weekly', 'daily' );
-
-		// Verify cron still exists (just with new frequency).
-		$scheduled = wp_next_scheduled( 'pr_core_verification_scan' );
-		$this->assertNotFalse( $scheduled );
-	}
-
-	/**
-	 * Test that same cadence does not reschedule.
-	 */
-	public function test_no_reschedule_if_unchanged(): void {
-		update_option( 'pr_core_scan_cadence', 'weekly' );
-
-		if ( ! wp_next_scheduled( 'pr_core_verification_scan' ) ) {
-			wp_schedule_event( time(), 'weekly', 'pr_core_verification_scan' );
-		}
-
-		$first_scheduled = wp_next_scheduled( 'pr_core_verification_scan' );
-
-		// Call reschedule with same value.
-		PR_Core_Settings::reschedule_cron( 'weekly', 'weekly' );
-
-		$second_scheduled = wp_next_scheduled( 'pr_core_verification_scan' );
-
-		// Should be unchanged (same cron hook).
-		$this->assertEquals( $first_scheduled, $second_scheduled );
-	}
-
-	/**
-	 * Test cadence sanitization.
-	 */
-	public function test_sanitize_cadence(): void {
-		$this->assertEquals( 'daily', PR_Core_Settings::sanitize_cadence( 'daily' ) );
-		$this->assertEquals( 'weekly', PR_Core_Settings::sanitize_cadence( 'weekly' ) );
-		$this->assertEquals( 'monthly', PR_Core_Settings::sanitize_cadence( 'monthly' ) );
-		$this->assertEquals( 'weekly', PR_Core_Settings::sanitize_cadence( 'invalid' ) );
-	}
-
-	/**
-	 * Test email sanitization.
-	 */
-	public function test_sanitize_emails(): void {
-		$input = 'admin@example.com, editor@example.com';
-		$output = PR_Core_Settings::sanitize_emails( $input );
-		$this->assertStringContainsString( 'admin@example.com', $output );
-		$this->assertStringContainsString( 'editor@example.com', $output );
-
-		// Invalid emails filtered out.
-		$input_bad = 'admin@example.com, invalid-email, editor@example.com';
-		$output = PR_Core_Settings::sanitize_emails( $input_bad );
-		$this->assertStringContainsString( 'admin@example.com', $output );
-		$this->assertStringContainsString( 'editor@example.com', $output );
-		$this->assertStringNotContainsString( 'invalid-email', $output );
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( string $key, $default = false ) {
+		return $GLOBALS['pr_core_options'][ $key ] ?? $default;
 	}
 }
+
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( string $key, $value ): bool {
+		$GLOBALS['pr_core_options'][ $key ] = $value;
+		return true;
+	}
+}
+
+if ( ! function_exists( 'register_setting' ) ) {
+	function register_setting( string $group, string $option, array $args = [] ): void {}
+}
+
+if ( ! function_exists( 'add_settings_section' ) ) {
+	function add_settings_section( string $id, string $title, $cb, string $page ): void {}
+}
+
+if ( ! function_exists( 'add_settings_field' ) ) {
+	function add_settings_field( string $id, string $title, $cb, string $page, string $section = '' ): void {}
+}
+
+if ( ! function_exists( 'is_email' ) ) {
+	function is_email( string $email ): bool {
+		return (bool) filter_var( $email, FILTER_VALIDATE_EMAIL );
+	}
+}
+
+if ( ! function_exists( 'wp_clear_scheduled_hook' ) ) {
+	function wp_clear_scheduled_hook( string $hook ): void {
+		$GLOBALS['pr_core_cron_calls'][] = [ 'action' => 'clear', 'hook' => $hook ];
+	}
+}
+
+if ( ! function_exists( 'wp_schedule_event' ) ) {
+	function wp_schedule_event( int $timestamp, string $recurrence, string $hook ): void {
+		$GLOBALS['pr_core_cron_calls'][] = [ 'action' => 'schedule', 'hook' => $hook, 'recurrence' => $recurrence ];
+	}
+}
+
+// ── Load the settings class ─────────────────────────────────────────────
+
+require_once __DIR__ . '/../../includes/cpt/class-pr-core-peptide-cpt.php';
+require_once __DIR__ . '/../../includes/admin/class-pr-core-settings.php';
+
+echo "== PR_Core_Settings verification methods unit tests ==\n\n";
+
+// ── sanitize_cadence() ──────────────────────────────────────────────────
+
+echo "sanitize_cadence():\n";
+pr_assert_equals( 'daily',   PR_Core_Settings::sanitize_cadence( 'daily' ),   'daily → daily' );
+pr_assert_equals( 'weekly',  PR_Core_Settings::sanitize_cadence( 'weekly' ),  'weekly → weekly' );
+pr_assert_equals( 'monthly', PR_Core_Settings::sanitize_cadence( 'monthly' ), 'monthly → monthly' );
+pr_assert_equals( 'weekly',  PR_Core_Settings::sanitize_cadence( 'hourly' ),  'hourly (invalid) → weekly default' );
+pr_assert_equals( 'weekly',  PR_Core_Settings::sanitize_cadence( '' ),        'empty → weekly default' );
+pr_assert_equals( 'weekly',  PR_Core_Settings::sanitize_cadence( 'DAILY' ),   'uppercase → weekly (case-sensitive)' );
+
+// ── sanitize_emails() ───────────────────────────────────────────────────
+
+echo "\nsanitize_emails():\n";
+pr_assert_equals( '',                    PR_Core_Settings::sanitize_emails( '' ),                              'empty → empty' );
+pr_assert_equals( 'admin@example.com',   PR_Core_Settings::sanitize_emails( 'admin@example.com' ),            'valid single → kept' );
+pr_assert_equals( '',                    PR_Core_Settings::sanitize_emails( 'not-an-email' ),                  'invalid single → empty' );
+pr_assert_equals( 'a@test.com, b@test.com', PR_Core_Settings::sanitize_emails( 'a@test.com, b@test.com' ),    'valid pair → both kept' );
+pr_assert_equals( 'good@test.com',       PR_Core_Settings::sanitize_emails( 'good@test.com, bad-email' ),     'mixed → only valid kept' );
+pr_assert_equals( 'trimmed@test.com',    PR_Core_Settings::sanitize_emails( '  trimmed@test.com  ' ),         'whitespace trimmed around valid email' );
+
+// ── reschedule_cron(): no-op when same value ────────────────────────────
+
+echo "\nreschedule_cron() — no-op when value unchanged:\n";
+$GLOBALS['pr_core_cron_calls'] = [];
+PR_Core_Settings::reschedule_cron( 'weekly', 'weekly' );
+pr_assert( empty( $GLOBALS['pr_core_cron_calls'] ), 'no cron calls when old === new' );
+
+// ── reschedule_cron(): clears + reschedules on change ───────────────────
+
+echo "\nreschedule_cron() — reschedules when value changes:\n";
+$GLOBALS['pr_core_cron_calls'] = [];
+PR_Core_Settings::reschedule_cron( 'weekly', 'daily' );
+
+$actions = array_column( $GLOBALS['pr_core_cron_calls'], 'action' );
+pr_assert( in_array( 'clear', $actions, true ),    'wp_clear_scheduled_hook was called' );
+pr_assert( in_array( 'schedule', $actions, true ),  'wp_schedule_event was called' );
+
+$schedule_call = null;
+foreach ( $GLOBALS['pr_core_cron_calls'] as $call ) {
+	if ( 'schedule' === $call['action'] ) {
+		$schedule_call = $call;
+		break;
+	}
+}
+pr_assert( null !== $schedule_call,                                                    'schedule call found' );
+pr_assert_equals( 'pr_core_verification_scan', $schedule_call['hook'] ?? '',           'rescheduled hook = pr_core_verification_scan' );
+pr_assert_equals( 'daily', $schedule_call['recurrence'] ?? '',                         'rescheduled with new cadence "daily"' );
+
+// Clear fires before schedule (correct ordering).
+$clear_idx    = array_search( 'clear', $actions, true );
+$schedule_idx = array_search( 'schedule', $actions, true );
+pr_assert( $clear_idx < $schedule_idx, 'clear fires before schedule' );
+
+// ── Summary ─────────────────────────────────────────────────────────────
+
+exit( pr_test_summary() );


### PR DESCRIPTION
## PR Core v0.4.0 — Verification Scanner

Builds the recurring verification scanner described in the Phase 2 brief.

### New files
- `includes/scanner/class-pr-core-verification-scanner.php` — WP-cron-driven scanner; computes `_pr_verification_status` (current/due/overdue) per post based on velocity thresholds; logs scan summaries; sends email digest
- `includes/admin/class-pr-core-verification-widget.php` — Dashboard widget listing due/overdue monographs with Scan Now button
- `includes/admin/class-pr-core-verification-metabox.php` — Sidebar meta box on peptide edit screen: last-verified date, velocity dropdown, status badge, Mark Verified Today button
- `includes/admin/class-pr-core-ajax-handlers.php` — Ajax handlers for mark-verified and scan-now actions
- `includes/frontend/class-pr-core-verification-display.php` — Appends `Last verified: [date] — methodology` after verdict card via `the_content` filter
- `includes/cpt/class-pr-core-verification-sanitizers.php` — Enum sanitizers for velocity and status fields
- `tests/unit/test-verification-scanner.php` — Unit tests for status computation (zero DB calls)
- `tests/unit/test-verification-settings.php` — Unit tests for cron reschedule on cadence change

### Modified files
- `class-pr-core-settings.php` — Rebuilt as static class; adds Verification section (cadence, thresholds, email) alongside existing Related Articles section; settings page restored
- `class-pr-core.php` — Wires cron, ajax handlers (outside is_admin — required for admin-ajax.php), settings page and widget registration
- `class-pr-core-peptide-cpt.php` — Registers 6 new meta fields: `_pr_last_source_verified`, `_pr_last_reviewed`, `_pr_next_review_by`, `_pr_verification_velocity`, `_pr_verification_notes`, `_pr_verification_status`
- `class-pr-core-admin.php` — Updated for new class dependencies
- `class-pr-core-deactivator.php` — Clears verification cron on deactivate

### All files under 300 lines. Version bumped to 0.4.0.