### PR TITLE
ci: restore deploy pipeline (remove invalid continue-on-error)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,6 @@ jobs:
   smoke:
     name: Smoke tests (staging)
     needs: deploy-staging
-    continue-on-error: true
     uses: peptiderepo/peptide-e2e/.github/workflows/smoke.yml@main
     secrets:
       STAGING_WP_ADMIN_USER: ${{ secrets.STAGING_WP_ADMIN_USER }}


### PR DESCRIPTION
Removes the invalid `continue-on-error` on the `uses:` smoke job (0-job failure that has blocked every deploy — why v0.5.0 never reached prod). Same fix as prautoblogger #147. Merging triggers a deploy of current main (v0.5.0); prod gate approval will follow. — CTO