### PR TITLE
ci(audit): retry PR-association check (stop squash-merge false positives) + header v0.5.0

### DIFF
--- a/.github/workflows/main-push-audit.yml
+++ b/.github/workflows/main-push-audit.yml
@@ -29,12 +29,22 @@ jobs:
         with:
           script: |
             const sha = context.sha;
-            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              commit_sha: sha,
-            });
-            const merged = prs.find(p => p.merged_at);
+            // Squash-merge -> PR association is eventually-consistent; poll briefly
+            // before concluding this was a direct push (avoids false positives on merges).
+            async function findMergedPR() {
+              for (let attempt = 1; attempt <= 5; attempt++) {
+                const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  commit_sha: sha,
+                });
+                const m = prs.find(p => p.merged_at);
+                if (m) return m;
+                if (attempt < 5) await new Promise(r => setTimeout(r, 10000));
+              }
+              return null;
+            }
+            const merged = await findMergedPR();
             if (merged) {
               core.info(`OK: commit ${sha.substring(0,7)} came from PR #${merged.number}`);
               return;

--- a/peptide-repo-core.php
+++ b/peptide-repo-core.php
@@ -3,7 +3,7 @@
  * Plugin Name: Peptide Repo Core
  * Plugin URI:  https://peptiderepo.com
  * Description: Canonical peptide schema — shared data layer for the peptiderepo.com ecosystem. Provides the peptide CPT, dosing rows, legal status cells, AI candidate queue, disclaimer component, and JSON-LD output.
- * Version:     0.4.0
+ * Version:     0.5.0
  * Author:      peptiderepo
  * Author URI:  https://peptiderepo.com
  * License:     GPL-2.0-or-later


### PR DESCRIPTION
Fixes the audit tripwire's race: `listPullRequestsAssociatedWithCommit` is eventually-consistent after a squash-merge, so the single immediate check intermittently filed false `Direct push to main` issues on legitimate PR merges. Now retries up to 5×/10s before concluding. — CTO

Also bumps the plugin header `Version:` from 0.4.0 to 0.5.0 to match the `PR_CORE_VERSION` constant (WP admin was showing the wrong version).