### PR TITLE
ci: adopt shared reusable deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,88 +16,10 @@ jobs:
     name: Pre-deploy CI
     uses: ./.github/workflows/ci.yml
 
-  deploy-staging:
-    name: Deploy to Staging
+  deploy:
+    name: Deploy (shared pipeline)
     needs: ci
-    runs-on: ubuntu-latest
-    environment: staging
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup SSH key
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -p ${{ secrets.SSH_PORT }} ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
-      - name: Deploy via rsync → staging
-        run: |
-          rsync -avz --delete \
-            --exclude '.git' --exclude '.github' \
-            --exclude 'tests' --exclude 'phpunit.xml.dist' \
-            --exclude 'composer.json' --exclude 'composer.lock' \
-            --exclude 'vendor' --exclude 'phpcs.xml.dist' \
-            --exclude 'ARCHITECTURE.md' --exclude 'CONVENTIONS.md' --exclude 'CHANGELOG.md' \
-            -e "ssh -i ~/.ssh/deploy_key -p ${{ secrets.SSH_PORT }}" \
-            ./ ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }}:~/domains/peptiderepo.com/public_html/staging/wp-content/plugins/peptide-repo-core/
-      - name: Staging health check
-        run: |
-          sleep 5
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://staging.peptiderepo.com/ || echo "000")
-          echo "Staging responded: HTTP $STATUS"
-      - name: Cleanup
-        if: always()
-        run: rm -f ~/.ssh/deploy_key
-
-  smoke:
-    name: Smoke tests (staging)
-    needs: deploy-staging
-    uses: peptiderepo/peptide-e2e/.github/workflows/smoke.yml@main
-    secrets:
-      STAGING_WP_ADMIN_USER: ${{ secrets.STAGING_WP_ADMIN_USER }}
-      STAGING_WP_ADMIN_PASSWORD: ${{ secrets.STAGING_WP_ADMIN_PASSWORD }}
-
-  deploy-production:
-    name: Deploy to Production
-    needs: [ci, deploy-staging]  # smoke is informational; not gating prod
-    runs-on: ubuntu-latest
-    environment: production
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup SSH key
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -p ${{ secrets.SSH_PORT }} ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
-      - name: Deploy via rsync → production
-        run: |
-          rsync -avz --delete \
-            --exclude '.git' --exclude '.github' \
-            --exclude 'tests' --exclude 'phpunit.xml.dist' \
-            --exclude 'composer.json' --exclude 'composer.lock' \
-            --exclude 'vendor' --exclude 'phpcs.xml.dist' \
-            --exclude 'ARCHITECTURE.md' --exclude 'CONVENTIONS.md' --exclude 'CHANGELOG.md' \
-            -e "ssh -i ~/.ssh/deploy_key -p ${{ secrets.SSH_PORT }}" \
-            ./ ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }}:~/domains/peptiderepo.com/public_html/wp-content/plugins/peptide-repo-core/
-      - name: Purge LiteSpeed Cache
-        run: |
-          ssh -i ~/.ssh/deploy_key -p ${{ secrets.SSH_PORT }} \
-            ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }} \
-            "cd ~/domains/peptiderepo.com/public_html && find wp-content/litespeed/ -type f -delete 2>/dev/null; touch .lscache_purge 2>/dev/null || true"
-      - name: Production health check
-        run: |
-          sleep 5
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://peptiderepo.com)
-          if [ "$STATUS" != "200" ] && [ "$STATUS" != "403" ]; then
-            echo "ERROR: Site returned HTTP $STATUS"
-            exit 1
-          fi
-          echo "Production healthy (HTTP $STATUS)"
-      - name: Cleanup
-        if: always()
-        run: rm -f ~/.ssh/deploy_key
-      - name: Deploy summary
-        run: |
-          echo "## Deployment Complete" >> $GITHUB_STEP_SUMMARY
-          echo "- **Commit:** \`${GITHUB_SHA::7}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Deployed to:** peptiderepo.com" >> $GITHUB_STEP_SUMMARY
+    uses: peptiderepo/peptide-e2e/.github/workflows/deploy-app.yml@main
+    with:
+      target_path: wp-content/plugins/peptide-repo-core
+    secrets: inherit


### PR DESCRIPTION
Converts this repo's deploy to a thin caller of the shared `deploy-app.yml` (keeps the `ci` CI job, target_path `wp-content/plugins/peptide-repo-core`). Pilot (calculator) deployed green end-to-end. — CTO