### PR TITLE
fix: resolve PR_Core_Settings_Renderer undefined constant fatal (v0.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Peptide Repo Core are documented here.
 Format: [Semantic Versioning](https://semver.org/).
 
 
+## [0.7.1] - 2026-06-17
+
+### Fixed
+- **Critical**: Settings page PHP Fatal `Undefined constant PR_Core_Settings_Renderer::OPTION_GROUP` (and 6 other `self::CONST` references). Root cause: PR #22 split the renderer into its own class but left all constants defined only on `PR_Core_Settings`. Fix: promote the 6 option-key private constants to `public const` on `PR_Core_Settings`; update renderer to reference them via `PR_Core_Settings::*`. Regression introduced in v0.7.0.
+
 ## [0.7.0] - 2026-06-16
 
 ### Changed

--- a/includes/admin/class-pr-core-settings-renderer.php
+++ b/includes/admin/class-pr-core-settings-renderer.php
@@ -35,8 +35,8 @@ class PR_Core_Settings_Renderer {
 			<h1><?php esc_html_e( 'PR Core Settings', 'peptide-repo-core' ); ?></h1>
 			<form method="post" action="options.php">
 				<?php
-				settings_fields( self::OPTION_GROUP );
-				do_settings_sections( self::OPTION_GROUP );
+				settings_fields( PR_Core_Settings::OPTION_GROUP );
+				do_settings_sections( PR_Core_Settings::OPTION_GROUP );
 				submit_button();
 				?>
 			</form>
@@ -50,10 +50,10 @@ class PR_Core_Settings_Renderer {
 	 * @return void
 	 */
 	public static function render_enabled_field(): void {
-		$enabled = (bool) get_option( self::RELATED_ENABLED, true );
+		$enabled = (bool) get_option( PR_Core_Settings::RELATED_ENABLED, true );
 		printf(
 			'<input type="checkbox" name="%s" value="1"%s /> %s',
-			esc_attr( self::RELATED_ENABLED ),
+			esc_attr( PR_Core_Settings::RELATED_ENABLED ),
 			checked( $enabled, true, false ),
 			esc_html__( 'Show related monographs on single peptide pages', 'peptide-repo-core' )
 		);
@@ -67,8 +67,8 @@ class PR_Core_Settings_Renderer {
 	public static function render_limit_field(): void {
 		printf(
 			'<input type="number" name="%s" value="%d" min="1" max="6" />',
-			esc_attr( self::RELATED_LIMIT ),
-			absint( get_option( self::RELATED_LIMIT, 3 ) )
+			esc_attr( PR_Core_Settings::RELATED_LIMIT ),
+			absint( get_option( PR_Core_Settings::RELATED_LIMIT, 3 ) )
 		);
 		echo '<p class="description">' . esc_html__( 'Number of articles to display (1-6). Default: 3.', 'peptide-repo-core' ) . '</p>';
 	}
@@ -88,8 +88,8 @@ class PR_Core_Settings_Renderer {
 	 * @return void
 	 */
 	public static function render_cadence_field(): void {
-		$current = get_option( self::SCAN_CADENCE, 'weekly' );
-		echo '<select name="' . esc_attr( self::SCAN_CADENCE ) . '">';
+		$current = get_option( PR_Core_Settings::SCAN_CADENCE, 'weekly' );
+		echo '<select name="' . esc_attr( PR_Core_Settings::SCAN_CADENCE ) . '">';
 		foreach ( array(
 			'daily'   => 'Daily',
 			'weekly'  => 'Weekly',
@@ -106,7 +106,7 @@ class PR_Core_Settings_Renderer {
 	 * @return void
 	 */
 	public static function render_threshold_field(): void {
-		printf( '<input type="number" name="%s" value="%d" min="1" />', esc_attr( self::DEFAULT_THRESHOLD ), absint( get_option( self::DEFAULT_THRESHOLD, 180 ) ) );
+		printf( '<input type="number" name="%s" value="%d" min="1" />', esc_attr( PR_Core_Settings::DEFAULT_THRESHOLD ), absint( get_option( PR_Core_Settings::DEFAULT_THRESHOLD, 180 ) ) );
 	}
 
 	/**
@@ -115,7 +115,7 @@ class PR_Core_Settings_Renderer {
 	 * @return void
 	 */
 	public static function render_high_velocity_field(): void {
-		printf( '<input type="number" name="%s" value="%d" min="1" />', esc_attr( self::HIGH_VELOCITY_THRESHOLD ), absint( get_option( self::HIGH_VELOCITY_THRESHOLD, 60 ) ) );
+		printf( '<input type="number" name="%s" value="%d" min="1" />', esc_attr( PR_Core_Settings::HIGH_VELOCITY_THRESHOLD ), absint( get_option( PR_Core_Settings::HIGH_VELOCITY_THRESHOLD, 60 ) ) );
 	}
 
 	/**
@@ -126,8 +126,8 @@ class PR_Core_Settings_Renderer {
 	public static function render_email_field(): void {
 		printf(
 			'<input type="text" name="%s" value="%s" class="regular-text" placeholder="admin@example.com" />',
-			esc_attr( self::VERIFICATION_EMAIL ),
-			esc_attr( (string) get_option( self::VERIFICATION_EMAIL, '' ) )
+			esc_attr( PR_Core_Settings::VERIFICATION_EMAIL ),
+			esc_attr( (string) get_option( PR_Core_Settings::VERIFICATION_EMAIL, '' ) )
 		);
 		echo '<p class="description">' . esc_html__( 'Comma-separated. Leave blank to disable email digests.', 'peptide-repo-core' ) . '</p>';
 	}

--- a/includes/admin/class-pr-core-settings.php
+++ b/includes/admin/class-pr-core-settings.php
@@ -23,22 +23,22 @@ class PR_Core_Settings {
 	public const OPTION_GROUP = 'pr_core_settings';
 
 	/** @var string Option key: enable/disable related articles. */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
-	private const RELATED_ENABLED = 'pr_core_related_posts_enabled';
+	public const RELATED_ENABLED = 'pr_core_related_posts_enabled';
 
 	/** @var string Option key: related articles limit (1-6). */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
-	private const RELATED_LIMIT = 'pr_core_related_posts_limit';
+	public const RELATED_LIMIT = 'pr_core_related_posts_limit';
 
 	/** @var string Option key: WP-cron scan cadence. */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
-	private const SCAN_CADENCE = 'pr_core_scan_cadence';
+	public const SCAN_CADENCE = 'pr_core_scan_cadence';
 
 	/** @var string Option key: default staleness threshold in days. */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
-	private const DEFAULT_THRESHOLD = 'pr_core_default_threshold';
+	public const DEFAULT_THRESHOLD = 'pr_core_default_threshold';
 
 	/** @var string Option key: high-velocity staleness threshold in days. */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
-	private const HIGH_VELOCITY_THRESHOLD = 'pr_core_high_velocity_threshold';
+	public const HIGH_VELOCITY_THRESHOLD = 'pr_core_high_velocity_threshold';
 
 	/** @var string Option key: comma-separated notification email list. */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
-	private const VERIFICATION_EMAIL = 'pr_core_verification_email';
+	public const VERIFICATION_EMAIL = 'pr_core_verification_email';
 
 	/**
 	 * Register the settings submenu page under Peptides.

--- a/peptide-repo-core.php
+++ b/peptide-repo-core.php
@@ -9,7 +9,7 @@
  * Plugin Name: Peptide Repo Core
  * Plugin URI:  https://peptiderepo.com
  * Description: Canonical peptide schema — shared data layer for the peptiderepo.com ecosystem. Provides the peptide CPT, dosing rows, legal status cells, AI candidate queue, disclaimer component, and JSON-LD output.
- * Version:     0.7.0
+ * Version:     0.7.1
  * Author:      peptiderepo
  * Author URI:  https://peptiderepo.com
  * License:     GPL-2.0-or-later
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /* ── Constants ────────────────────────────────────────────────────────── */
 
-define( 'PR_CORE_VERSION', '0.7.0' );
+define( 'PR_CORE_VERSION', '0.7.1' );
 define( 'PR_CORE_PLUGIN_FILE', __FILE__ );
 define( 'PR_CORE_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PR_CORE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/tests/unit/SettingsRendererTest.php
+++ b/tests/unit/SettingsRendererTest.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Regression tests for PR_Core_Settings_Renderer constant references.
+ *
+ * Covers the regression introduced in v0.7.0 (#22): the renderer class was
+ * split out of PR_Core_Settings but all self::CONST references were left
+ * pointing at constants only defined on PR_Core_Settings. This caused
+ * PHP Fatal: Undefined constant PR_Core_Settings_Renderer::OPTION_GROUP
+ * (and 6 others) on every load of the Settings admin page.
+ *
+ * Fix (v0.7.1): constants promoted to public on PR_Core_Settings; renderer
+ * references them as PR_Core_Settings::*.
+ *
+ * @package PeptideRepoCore\Tests
+ */
+
+use PHPUnit\Framework\TestCase;
+
+// ── Additional WP stubs required by the renderer's render_*() methods ─────
+
+if ( ! function_exists( 'checked' ) ) {
+	function checked( $checked, $current = true, bool $echo = true ): string {
+		$result = $checked === $current ? ' checked="checked"' : '';
+		if ( $echo ) {
+			echo $result;
+		}
+		return $result;
+	}
+}
+
+if ( ! function_exists( 'selected' ) ) {
+	function selected( $selected, $current = true, bool $echo = true ): string {
+		$result = $selected === $current ? ' selected="selected"' : '';
+		if ( $echo ) {
+			echo $result;
+		}
+		return $result;
+	}
+}
+
+if ( ! function_exists( 'settings_fields' ) ) {
+	function settings_fields( string $option_group ): void {}
+}
+
+if ( ! function_exists( 'do_settings_sections' ) ) {
+	function do_settings_sections( string $page ): void {}
+}
+
+if ( ! function_exists( 'submit_button' ) ) {
+	function submit_button(): void {}
+}
+
+/**
+ * Tests that PR_Core_Settings_Renderer resolves its constants without fatals.
+ */
+class SettingsRendererTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['pr_core_options']    = [];
+		$GLOBALS['pr_core_cron_calls'] = [];
+		$GLOBALS['pr_core_test_state'] = [
+			'existing_post_types'   => [],
+			'existing_taxonomies'   => [],
+			'registered_post_types' => [],
+			'registered_taxonomies' => [],
+			'registered_meta'       => [],
+			'added_actions'         => [],
+			'added_filters'         => [],
+		];
+		require_once PR_CORE_PLUGIN_DIR . 'includes/cpt/class-pr-core-peptide-cpt.php';
+		require_once PR_CORE_PLUGIN_DIR . 'includes/admin/class-pr-core-settings.php';
+		require_once PR_CORE_PLUGIN_DIR . 'includes/admin/class-pr-core-settings-renderer.php';
+	}
+
+	// ── Cross-class constant accessibility ────────────────────────────────.
+
+	/**
+	 * OPTION_GROUP must be a non-empty string on PR_Core_Settings.
+	 * Renderer calls PR_Core_Settings::OPTION_GROUP — verifies it resolves.
+	 */
+	public function test_option_group_constant_accessible_on_settings(): void {
+		$this->assertNotEmpty( PR_Core_Settings::OPTION_GROUP );
+		$this->assertIsString( PR_Core_Settings::OPTION_GROUP );
+	}
+
+	public function test_related_enabled_constant_accessible(): void {
+		$this->assertNotEmpty( PR_Core_Settings::RELATED_ENABLED );
+	}
+
+	public function test_related_limit_constant_accessible(): void {
+		$this->assertNotEmpty( PR_Core_Settings::RELATED_LIMIT );
+	}
+
+	public function test_scan_cadence_constant_accessible(): void {
+		$this->assertNotEmpty( PR_Core_Settings::SCAN_CADENCE );
+	}
+
+	public function test_default_threshold_constant_accessible(): void {
+		$this->assertNotEmpty( PR_Core_Settings::DEFAULT_THRESHOLD );
+	}
+
+	public function test_high_velocity_threshold_constant_accessible(): void {
+		$this->assertNotEmpty( PR_Core_Settings::HIGH_VELOCITY_THRESHOLD );
+	}
+
+	public function test_verification_email_constant_accessible(): void {
+		// Value is intentionally a non-empty option key string.
+		$this->assertIsString( PR_Core_Settings::VERIFICATION_EMAIL );
+		$this->assertNotEmpty( PR_Core_Settings::VERIFICATION_EMAIL );
+	}
+
+	// ── Renderer render_*_field: no fatal on constant resolution ─────────.
+
+	/**
+	 * render_enabled_field() calls PR_Core_Settings::RELATED_ENABLED twice.
+	 * Before the fix this fatalled. Capture output to confirm no crash.
+	 */
+	public function test_render_enabled_field_no_fatal(): void {
+		ob_start();
+		PR_Core_Settings_Renderer::render_enabled_field();
+		$output = ob_get_clean();
+		$this->assertStringContainsString( 'type="checkbox"', $output );
+	}
+
+	/**
+	 * render_limit_field() calls PR_Core_Settings::RELATED_LIMIT twice.
+	 */
+	public function test_render_limit_field_no_fatal(): void {
+		ob_start();
+		PR_Core_Settings_Renderer::render_limit_field();
+		$output = ob_get_clean();
+		$this->assertStringContainsString( 'type="number"', $output );
+	}
+
+	/**
+	 * render_cadence_field() calls PR_Core_Settings::SCAN_CADENCE twice.
+	 */
+	public function test_render_cadence_field_no_fatal(): void {
+		ob_start();
+		PR_Core_Settings_Renderer::render_cadence_field();
+		$output = ob_get_clean();
+		$this->assertStringContainsString( '<select', $output );
+	}
+
+	/**
+	 * render_threshold_field() calls PR_Core_Settings::DEFAULT_THRESHOLD twice.
+	 */
+	public function test_render_threshold_field_no_fatal(): void {
+		ob_start();
+		PR_Core_Settings_Renderer::render_threshold_field();
+		$output = ob_get_clean();
+		$this->assertStringContainsString( 'type="number"', $output );
+	}
+
+	/**
+	 * render_high_velocity_field() calls PR_Core_Settings::HIGH_VELOCITY_THRESHOLD twice.
+	 */
+	public function test_render_high_velocity_field_no_fatal(): void {
+		ob_start();
+		PR_Core_Settings_Renderer::render_high_velocity_field();
+		$output = ob_get_clean();
+		$this->assertStringContainsString( 'type="number"', $output );
+	}
+
+	/**
+	 * render_email_field() calls PR_Core_Settings::VERIFICATION_EMAIL twice.
+	 */
+	public function test_render_email_field_no_fatal(): void {
+		ob_start();
+		PR_Core_Settings_Renderer::render_email_field();
+		$output = ob_get_clean();
+		$this->assertStringContainsString( 'type="text"', $output );
+	}
+
+	// ── Constant value contracts ──────────────────────────────────────────.
+
+	public function test_option_group_value(): void {
+		$this->assertSame( 'pr_core_settings', PR_Core_Settings::OPTION_GROUP );
+	}
+
+	public function test_related_enabled_value(): void {
+		$this->assertSame( 'pr_core_related_posts_enabled', PR_Core_Settings::RELATED_ENABLED );
+	}
+
+	public function test_related_limit_value(): void {
+		$this->assertSame( 'pr_core_related_posts_limit', PR_Core_Settings::RELATED_LIMIT );
+	}
+
+	public function test_scan_cadence_value(): void {
+		$this->assertSame( 'pr_core_scan_cadence', PR_Core_Settings::SCAN_CADENCE );
+	}
+
+	public function test_default_threshold_value(): void {
+		$this->assertSame( 'pr_core_default_threshold', PR_Core_Settings::DEFAULT_THRESHOLD );
+	}
+
+	public function test_high_velocity_threshold_value(): void {
+		$this->assertSame( 'pr_core_high_velocity_threshold', PR_Core_Settings::HIGH_VELOCITY_THRESHOLD );
+	}
+
+	public function test_verification_email_value(): void {
+		$this->assertSame( 'pr_core_verification_email', PR_Core_Settings::VERIFICATION_EMAIL );
+	}
+}


### PR DESCRIPTION
## What changed
- `PR_Core_Settings`: promoted 6 option-key constants from `private const` to `public const` so the renderer class can reference them.
- `PR_Core_Settings_Renderer`: replaced all `self::OPTION_GROUP`, `self::RELATED_ENABLED`, `self::RELATED_LIMIT`, `self::SCAN_CADENCE`, `self::DEFAULT_THRESHOLD`, `self::HIGH_VELOCITY_THRESHOLD`, `self::VERIFICATION_EMAIL` with `PR_Core_Settings::*` (the class that defines them).
- Added regression test `tests/unit/SettingsRendererTest.php`.
- Version bump 0.7.0 → 0.7.1.

## Why
PR #22 split the renderer into its own class but left all constants on `PR_Core_Settings`. Every `self::OPTION_GROUP` (and 6 others) in the renderer resolved to an undefined constant → PHP Fatal → HTTP 500 on the Settings admin page.

## Risk flags
Low. No logic change — purely resolves the cross-class constant reference.

## Test plan
- PHP lint: both files pass `php -l`.
- New unit test `SettingsRendererTest.php` exercises constant access and all render_*_field() methods without fatal.
- CI PHPUnit must pass.
- Manual verify: navigate to Settings page as rhys → should render without 500.